### PR TITLE
feat: Add foundational modules (config, diagram_types, nodes)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ test = [
 dev = [
     "ruff",
     "mypy",
+    "types-docutils",
     { include-group = "test" },
 ]
 docs = [

--- a/src/sphinx_oceanid/config.py
+++ b/src/sphinx_oceanid/config.py
@@ -1,0 +1,93 @@
+"""Config definitions, validation, and CDN URL resolution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+_ConfigRebuild = Literal["", "env", "epub", "gettext", "html", "applehelp", "devhelp"]
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+BEAUTIFUL_MERMAID_VERSION = "1.1.3"
+BEAUTIFUL_MERMAID_CDN_TEMPLATE = "https://cdn.jsdelivr.net/npm/beautiful-mermaid@{version}/dist/index.js"
+
+SUPPORTED_DIAGRAM_TYPES: frozenset[str] = frozenset(
+    {
+        "flowchart",
+        "graph",  # flowchart alias
+        "stateDiagram",
+        "stateDiagram-v2",
+        "sequenceDiagram",
+        "classDiagram",
+        "erDiagram",
+        "xychart-beta",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ConfigSpec:
+    """Declarative specification for a single Sphinx config value."""
+
+    name: str
+    default: object
+    rebuild: _ConfigRebuild
+    types: type | tuple[type, ...]
+    description: str
+
+
+CONFIG_SPECS: tuple[ConfigSpec, ...] = (
+    # Rendering
+    ConfigSpec("oceanid_version", BEAUTIFUL_MERMAID_VERSION, "html", str, "beautiful-mermaid library version"),
+    ConfigSpec("oceanid_local_js", "", "html", str, "Path to local beautiful-mermaid JS bundle"),
+    ConfigSpec(
+        "oceanid_unsupported_action",
+        "warning",
+        "html",
+        str,
+        "Action for unsupported diagram types: 'warning' or 'error'",
+    ),
+    # Theme
+    ConfigSpec("oceanid_theme", "auto", "html", str, "Theme name or 'auto' for detection"),
+    ConfigSpec("oceanid_theme_dark", "zinc-dark", "html", str, "Dark theme when oceanid_theme='auto'"),
+    ConfigSpec("oceanid_theme_light", "zinc-light", "html", str, "Light theme when oceanid_theme='auto'"),
+    # Layout
+    ConfigSpec("oceanid_width", "100%", "html", str, "Diagram container width"),
+    ConfigSpec("oceanid_height", "auto", "html", str, "Diagram container height"),
+    # Feature flags
+    ConfigSpec("oceanid_zoom", False, "html", bool, "Enable zoom on all diagrams"),
+    ConfigSpec("oceanid_fullscreen", False, "html", bool, "Enable fullscreen modal"),
+    ConfigSpec("oceanid_fullscreen_button", "\u26f6", "html", str, "Fullscreen button character"),
+    ConfigSpec("oceanid_fullscreen_button_opacity", 50, "html", int, "Fullscreen button opacity (0-100)"),
+    ConfigSpec("oceanid_js_priority", 500, "html", int, "JS load priority"),
+)
+
+
+def register_config_values(app: Sphinx) -> None:
+    """Register all config values with Sphinx."""
+    for spec in CONFIG_SPECS:
+        app.add_config_value(
+            spec.name,
+            spec.default,
+            spec.rebuild,
+            types=spec.types,
+            description=spec.description,
+        )
+
+
+def resolve_js_url(config: object) -> str:
+    """Resolve beautiful-mermaid JS URL from Sphinx config.
+
+    Args:
+        config: Sphinx config object.
+
+    Returns:
+        URL string for the beautiful-mermaid JS bundle.
+    """
+    local_path: str = config.oceanid_local_js  # type: ignore[attr-defined]
+    if local_path:
+        return local_path
+    version: str = config.oceanid_version  # type: ignore[attr-defined]
+    return BEAUTIFUL_MERMAID_CDN_TEMPLATE.format(version=version)

--- a/src/sphinx_oceanid/diagram_types.py
+++ b/src/sphinx_oceanid/diagram_types.py
@@ -1,0 +1,55 @@
+"""Diagram type parsing and support detection (pure functions)."""
+
+from __future__ import annotations
+
+import re
+
+from .config import SUPPORTED_DIAGRAM_TYPES
+
+_FRONTMATTER_RE = re.compile(r"^---.*?---\s*", re.DOTALL)
+
+# All Mermaid diagram keywords (both supported and unsupported)
+_DIAGRAM_TYPE_RE = re.compile(
+    r"^\s*("
+    r"flowchart|graph|sequenceDiagram|classDiagram|"
+    r"stateDiagram(?:-v2)?|erDiagram|xychart-beta|"
+    r"gantt|pie|gitGraph|journey|mindmap|timeline|"
+    r"sankey-beta|quadrantChart|requirementDiagram|"
+    r"C4Context|C4Container|C4Component|C4Deployment|"
+    r"block-beta|packet-beta|kanban|architecture-beta|"
+    r"zenuml"
+    r")\b",
+    re.MULTILINE,
+)
+
+
+def extract_diagram_type(code: str) -> str | None:
+    """Extract diagram type from Mermaid code.
+
+    Skips YAML frontmatter (---...---) if present before parsing.
+
+    Args:
+        code: Mermaid notation string.
+
+    Returns:
+        Diagram type string, or None if not recognized.
+    """
+    stripped = _FRONTMATTER_RE.sub("", code)
+    match = _DIAGRAM_TYPE_RE.search(stripped)
+    if match:
+        return match.group(1)
+    return None
+
+
+def is_supported_diagram(diagram_type: str | None) -> bool:
+    """Check whether a diagram type is supported by beautiful-mermaid.
+
+    Args:
+        diagram_type: Return value from extract_diagram_type().
+
+    Returns:
+        True if the diagram type is supported.
+    """
+    if diagram_type is None:
+        return False
+    return diagram_type in SUPPORTED_DIAGRAM_TYPES

--- a/src/sphinx_oceanid/nodes.py
+++ b/src/sphinx_oceanid/nodes.py
@@ -1,0 +1,17 @@
+"""Docutils node definition for Mermaid diagrams."""
+
+from docutils import nodes
+
+
+class mermaid_node(nodes.General, nodes.Element):
+    """Docutils node representing a Mermaid diagram.
+
+    Attributes:
+        code: Mermaid notation string.
+        diagram_type: Parsed diagram type (e.g. "flowchart", "sequenceDiagram").
+        is_supported: Whether beautiful-mermaid supports this diagram type.
+        align: "left" | "center" | "right".
+        alt: Alternative text for accessibility.
+        zoom: Whether zoom is enabled.
+        zoom_id: Unique ID for the zoom element.
+    """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,80 @@
+"""Tests for sphinx_oceanid.config module."""
+
+from types import SimpleNamespace
+
+from sphinx_oceanid.config import (
+    BEAUTIFUL_MERMAID_CDN_TEMPLATE,
+    BEAUTIFUL_MERMAID_VERSION,
+    CONFIG_SPECS,
+    ConfigSpec,
+    resolve_js_url,
+)
+
+
+class TestConfigSpec:
+    """Tests for ConfigSpec dataclass."""
+
+    def test_config_spec_is_frozen(self) -> None:
+        spec = ConfigSpec("test", "default", "html", str, "desc")
+        assert spec.name == "test"
+        assert spec.default == "default"
+
+    def test_config_specs_all_have_unique_names(self) -> None:
+        """All config spec names must be unique."""
+        names = [spec.name for spec in CONFIG_SPECS]
+        assert len(names) == len(set(names))
+
+    def test_config_specs_all_have_oceanid_prefix(self) -> None:
+        """All config spec names must start with 'oceanid_'."""
+        for spec in CONFIG_SPECS:
+            assert spec.name.startswith("oceanid_"), f"{spec.name} missing oceanid_ prefix"
+
+    def test_config_specs_count(self) -> None:
+        """CONFIG_SPECS should contain exactly 13 settings."""
+        assert len(CONFIG_SPECS) == 13
+
+    def test_config_specs_all_rebuild_html(self) -> None:
+        """All config specs should trigger HTML rebuild."""
+        for spec in CONFIG_SPECS:
+            assert spec.rebuild == "html", f"{spec.name} rebuild is {spec.rebuild}, expected 'html'"
+
+
+class TestResolveJsUrl:
+    """Tests for resolve_js_url function."""
+
+    def test_resolve_js_url_default(self) -> None:
+        """Default config produces CDN URL with default version."""
+        config = SimpleNamespace(oceanid_local_js="", oceanid_version=BEAUTIFUL_MERMAID_VERSION)
+        url = resolve_js_url(config)
+        expected = BEAUTIFUL_MERMAID_CDN_TEMPLATE.format(version=BEAUTIFUL_MERMAID_VERSION)
+        assert url == expected
+
+    def test_resolve_js_url_custom_version(self) -> None:
+        """Custom version produces CDN URL with that version."""
+        config = SimpleNamespace(oceanid_local_js="", oceanid_version="2.0.0")
+        url = resolve_js_url(config)
+        expected = BEAUTIFUL_MERMAID_CDN_TEMPLATE.format(version="2.0.0")
+        assert url == expected
+
+    def test_resolve_js_url_local_path(self) -> None:
+        """Local path takes priority over CDN URL."""
+        config = SimpleNamespace(
+            oceanid_local_js="/static/beautiful-mermaid.js", oceanid_version=BEAUTIFUL_MERMAID_VERSION
+        )
+        url = resolve_js_url(config)
+        assert url == "/static/beautiful-mermaid.js"
+
+
+class TestConstants:
+    """Tests for module-level constants."""
+
+    def test_beautiful_mermaid_version(self) -> None:
+        assert BEAUTIFUL_MERMAID_VERSION == "1.1.3"
+
+    def test_cdn_template_contains_version_placeholder(self) -> None:
+        assert "{version}" in BEAUTIFUL_MERMAID_CDN_TEMPLATE
+
+    def test_cdn_template_produces_valid_url(self) -> None:
+        url = BEAUTIFUL_MERMAID_CDN_TEMPLATE.format(version="1.0.0")
+        assert url.startswith("https://")
+        assert "1.0.0" in url

--- a/tests/test_diagram_types.py
+++ b/tests/test_diagram_types.py
@@ -1,0 +1,104 @@
+"""Tests for sphinx_oceanid.diagram_types module."""
+
+import pytest
+
+from sphinx_oceanid.diagram_types import extract_diagram_type, is_supported_diagram
+
+
+class TestExtractDiagramType:
+    """Tests for extract_diagram_type function."""
+
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [
+            ("flowchart LR\n  A --> B", "flowchart"),
+            ("graph TD\n  A --> B", "graph"),
+            ("sequenceDiagram\n  Alice->>Bob: Hello", "sequenceDiagram"),
+            ("classDiagram\n  Animal <|-- Duck", "classDiagram"),
+            ("stateDiagram-v2\n  [*] --> Still", "stateDiagram-v2"),
+            ("stateDiagram\n  [*] --> Still", "stateDiagram"),
+            ("erDiagram\n  CUSTOMER ||--o{ ORDER : places", "erDiagram"),
+            ("xychart-beta\n  title My Chart", "xychart-beta"),
+        ],
+    )
+    def test_extract_supported_diagram_types(self, code: str, expected: str) -> None:
+        """Supported diagram types are correctly extracted."""
+        assert extract_diagram_type(code) == expected
+
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [
+            ("gantt\n  title A Gantt", "gantt"),
+            ("pie\n  title Pets", "pie"),
+            ("gitGraph\n  commit", "gitGraph"),
+            ("mindmap\n  root((mindmap))", "mindmap"),
+            ("timeline\n  title History", "timeline"),
+        ],
+    )
+    def test_extract_unsupported_diagram_types(self, code: str, expected: str) -> None:
+        """Unsupported diagram types are also correctly extracted."""
+        assert extract_diagram_type(code) == expected
+
+    def test_extract_with_frontmatter(self) -> None:
+        """Diagram type is extracted after YAML frontmatter."""
+        code = "---\ntitle: My Diagram\nconfig:\n  theme: dark\n---\nflowchart LR\n  A --> B"
+        assert extract_diagram_type(code) == "flowchart"
+
+    def test_extract_empty_string(self) -> None:
+        """Empty string returns None."""
+        assert extract_diagram_type("") is None
+
+    def test_extract_no_diagram_type(self) -> None:
+        """Unrecognized content returns None."""
+        assert extract_diagram_type("not a diagram\njust some text") is None
+
+    def test_extract_with_leading_whitespace(self) -> None:
+        """Leading whitespace before diagram type is handled."""
+        assert extract_diagram_type("  flowchart LR\n  A --> B") == "flowchart"
+
+    def test_extract_with_comments(self) -> None:
+        """Content that looks like a comment before diagram type."""
+        code = "%% This is a comment\nsequenceDiagram\n  Alice->>Bob: Hello"
+        # Comments are not diagram types, so the regex should find sequenceDiagram
+        assert extract_diagram_type(code) == "sequenceDiagram"
+
+
+class TestIsSupportedDiagram:
+    """Tests for is_supported_diagram function."""
+
+    @pytest.mark.parametrize(
+        "diagram_type",
+        [
+            "flowchart",
+            "graph",
+            "sequenceDiagram",
+            "classDiagram",
+            "stateDiagram",
+            "stateDiagram-v2",
+            "erDiagram",
+            "xychart-beta",
+        ],
+    )
+    def test_supported_types(self, diagram_type: str) -> None:
+        """All beautiful-mermaid supported types return True."""
+        assert is_supported_diagram(diagram_type) is True
+
+    def test_is_supported_none(self) -> None:
+        """None input returns False."""
+        assert is_supported_diagram(None) is False
+
+    @pytest.mark.parametrize(
+        "diagram_type",
+        [
+            "gantt",
+            "pie",
+            "gitGraph",
+            "mindmap",
+            "timeline",
+            "journey",
+            "sankey-beta",
+        ],
+    )
+    def test_unsupported_types(self, diagram_type: str) -> None:
+        """Unsupported diagram types return False."""
+        assert is_supported_diagram(diagram_type) is False

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,0 +1,61 @@
+"""Tests for sphinx_oceanid.nodes module."""
+
+from docutils import nodes
+
+from sphinx_oceanid.nodes import mermaid_node
+
+
+class TestMermaidNode:
+    """Tests for mermaid_node class."""
+
+    def test_mermaid_node_creation(self) -> None:
+        """mermaid_node can be instantiated with attributes."""
+        node = mermaid_node(
+            code="flowchart LR\n  A --> B",
+            diagram_type="flowchart",
+            is_supported=True,
+        )
+        assert node["code"] == "flowchart LR\n  A --> B"
+        assert node["diagram_type"] == "flowchart"
+        assert node["is_supported"] is True
+
+    def test_mermaid_node_default_attributes(self) -> None:
+        """mermaid_node has sensible defaults for optional attributes."""
+        node = mermaid_node(
+            code="sequenceDiagram\n  Alice->>Bob: Hello",
+            diagram_type="sequenceDiagram",
+            is_supported=True,
+        )
+        assert node.get("align") is None
+        assert node.get("alt") is None
+        assert node.get("zoom") is None
+        assert node.get("zoom_id") is None
+
+    def test_mermaid_node_with_all_attributes(self) -> None:
+        """mermaid_node accepts all documented attributes."""
+        node = mermaid_node(
+            code="erDiagram\n  A ||--o{ B : has",
+            diagram_type="erDiagram",
+            is_supported=True,
+            align="center",
+            alt="ER diagram",
+            zoom=True,
+            zoom_id="zoom-1",
+        )
+        assert node["code"] == "erDiagram\n  A ||--o{ B : has"
+        assert node["diagram_type"] == "erDiagram"
+        assert node["is_supported"] is True
+        assert node["align"] == "center"
+        assert node["alt"] == "ER diagram"
+        assert node["zoom"] is True
+        assert node["zoom_id"] == "zoom-1"
+
+    def test_mermaid_node_inherits_general(self) -> None:
+        """mermaid_node inherits from nodes.General."""
+        node = mermaid_node(code="", diagram_type=None, is_supported=False)
+        assert isinstance(node, nodes.General)
+
+    def test_mermaid_node_inherits_element(self) -> None:
+        """mermaid_node inherits from nodes.Element."""
+        node = mermaid_node(code="", diagram_type=None, is_supported=False)
+        assert isinstance(node, nodes.Element)

--- a/uv.lock
+++ b/uv.lock
@@ -542,6 +542,7 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "sphinx-revealjs" },
+    { name = "types-docutils" },
 ]
 docs = [
     { name = "myst-parser" },
@@ -564,6 +565,7 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "sphinx-revealjs" },
+    { name = "types-docutils" },
 ]
 docs = [
     { name = "myst-parser", specifier = ">=5.0.0" },
@@ -642,6 +644,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
+name = "types-docutils"
+version = "0.22.3.20260316"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/27/a7f16b3a2fad0a4ddd85a668319f9a1d0311c4bd9578894f6471c7e6c788/types_docutils-0.22.3.20260316.tar.gz", hash = "sha256:8ef27d565b9831ff094fe2eac75337a74151013e2d21ecabd445c2955f891564", size = 57263, upload-time = "2026-03-16T04:29:12.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/60/c1f22b7cfc4837d5419e5a2d8702c7d65f03343f866364b71cccd8a73b79/types_docutils-0.22.3.20260316-py3-none-any.whl", hash = "sha256:083c7091b8072c242998ec51da1bf1492f0332387da81c3b085efbf5ca754c7d", size = 91968, upload-time = "2026-03-16T04:29:11.114Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implement core modules for sphinx-oceanid:
- **config.py**: Configuration validation and CDN URL resolution
- **diagram_types.py**: Diagram type detection and support checking  
- **nodes.py**: mermaid_node docutils node definition with proper RST integration

All modules include comprehensive unit tests (53 tests passing).

Closes #2

## Test plan

- All 53 tests passing
- Quality checks passed: ruff check, ruff format, mypy
- Modules follow project architecture and design patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)