### PR TITLE
feat: Implement core Python modules for Sphinx extension

### DIFF
--- a/src/sphinx_oceanid/__init__.py
+++ b/src/sphinx_oceanid/__init__.py
@@ -13,10 +13,17 @@ __version__ = "0.1.0"
 def setup(app: Sphinx) -> dict[str, bool | str]:
     """Sphinx extension entry point.
 
-    Registers config values. Directives, visitors, and event
-    handlers will be added in subsequent implementation phases.
+    Registers nodes, directives, config values, and event handlers.
     """
+    from .assets import install_assets
     from .config import register_config_values
+    from .directives import Mermaid
+    from .nodes import mermaid_node
+    from .visitors import html_depart_mermaid, html_visit_mermaid
 
     register_config_values(app)
+    app.add_node(mermaid_node, html=(html_visit_mermaid, html_depart_mermaid))
+    app.add_directive("mermaid", Mermaid)
+    app.connect("html-page-context", install_assets)
+
     return {"version": __version__, "parallel_read_safe": True}

--- a/src/sphinx_oceanid/assets.py
+++ b/src/sphinx_oceanid/assets.py
@@ -1,0 +1,103 @@
+"""Per-page JS/CSS asset injection for Mermaid diagrams."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, cast
+
+from .config import resolve_js_url
+from .nodes import mermaid_node
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from docutils import nodes
+    from sphinx.application import Sphinx
+
+
+def install_assets(
+    app: Sphinx,
+    pagename: str,
+    templatename: str,
+    context: dict[str, object],
+    doctree: nodes.document | None,
+) -> None:
+    """Inject JS/CSS assets on pages containing mermaid_node.
+
+    Connected to the ``html-page-context`` event. Only injects assets
+    on pages that contain at least one mermaid diagram (FR-012).
+    """
+    if doctree is None:
+        return
+
+    mermaid_nodes = list(doctree.findall(mermaid_node))
+    if not mermaid_nodes:
+        return
+
+    page_config = _build_page_config(app, mermaid_nodes)
+    config_json = json.dumps(page_config, ensure_ascii=False)
+    beautiful_mermaid_url = cast("str", page_config["beautifulMermaidUrl"])
+
+    pathto = cast("Callable[[str, bool], str]", context["pathto"])
+    js_url = pathto("_static/oceanid-renderer.js", True)
+    css_url = pathto("_static/oceanid.css", True)
+
+    assets_html = (
+        f'\n<link rel="stylesheet" href="{css_url}" />\n'
+        f'<script type="application/json" id="oceanid-config">{config_json}</script>\n'
+        f"{_build_bootstrap_script(beautiful_mermaid_url)}\n"
+        f'<script type="module" src="{js_url}"></script>\n'
+    )
+
+    body = cast("str", context["body"])
+    context["body"] = body + assets_html
+
+
+def _build_page_config(
+    app: Sphinx,
+    mermaid_nodes: list[mermaid_node],
+) -> dict[str, object]:
+    """Build the per-page config JSON for JavaScript consumption."""
+    config = app.config
+
+    zoom_selectors: list[str] = []
+    for node in mermaid_nodes:
+        zoom_id: str = node.get("zoom_id", "")
+        if zoom_id:
+            zoom_selectors.append(f"#{zoom_id}")
+
+    return {
+        "beautifulMermaidUrl": resolve_js_url(config),
+        "theme": config.oceanid_theme,
+        "themeDark": config.oceanid_theme_dark,
+        "themeLight": config.oceanid_theme_light,
+        "width": config.oceanid_width,
+        "height": config.oceanid_height,
+        "zoom": config.oceanid_zoom,
+        "zoomSelectors": zoom_selectors,
+        "fullscreen": config.oceanid_fullscreen,
+        "fullscreenButton": config.oceanid_fullscreen_button,
+        "fullscreenButtonOpacity": config.oceanid_fullscreen_button_opacity,
+        "revealjs": app.builder.name == "revealjs",
+    }
+
+
+def _build_bootstrap_script(beautiful_mermaid_url: str) -> str:
+    """Build inline bootstrap script for FR-024 module load failure handling."""
+    safe_url = json.dumps(beautiful_mermaid_url)
+    return (
+        "<script>(function() {"
+        f"var url = {safe_url};"
+        "import(url).catch(function(err) {"
+        'document.querySelectorAll("[data-oceanid-code]").forEach(function(el) {'
+        'if (!el.querySelector(".oceanid-source-display")) {'
+        'var pre = document.createElement("pre");'
+        'pre.className = "oceanid-source-display";'
+        'pre.textContent = el.getAttribute("data-oceanid-code");'
+        "el.appendChild(pre);"
+        "}"
+        "});"
+        'console.error("sphinx-oceanid: Failed to load beautiful-mermaid:", err);'
+        "});"
+        "})();</script>"
+    )

--- a/src/sphinx_oceanid/directives.py
+++ b/src/sphinx_oceanid/directives.py
@@ -1,0 +1,60 @@
+"""Mermaid directive for RST (SphinxDirective-based)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from docutils.parsers.rst import directives
+from sphinx.util import logging
+from sphinx.util.docutils import SphinxDirective
+
+from .diagram_types import extract_diagram_type, is_supported_diagram
+from .nodes import mermaid_node
+
+if TYPE_CHECKING:
+    from docutils import nodes
+
+logger = logging.getLogger(__name__)
+
+
+class Mermaid(SphinxDirective):
+    """Sphinx directive for embedding Mermaid diagrams."""
+
+    has_content = True
+    required_arguments = 0
+    optional_arguments = 0
+    option_spec = {  # noqa: RUF012
+        "name": directives.unchanged,
+        "align": lambda arg: directives.choice(arg, ("left", "center", "right")),
+        "zoom": directives.flag,
+    }
+
+    def run(self) -> list[nodes.Node]:
+        """Parse directive content and create mermaid_node."""
+        code = self._get_code()
+        if not code.strip():
+            logger.warning(
+                "mermaid directive has empty content",
+                location=(self.env.docname, self.lineno),
+            )
+            return []
+
+        diagram_type = extract_diagram_type(code)
+        is_supported = is_supported_diagram(diagram_type)
+
+        node = mermaid_node()
+        node["code"] = code
+        node["diagram_type"] = diagram_type
+        node["is_supported"] = is_supported
+        node["align"] = self.options.get("align", "")
+        node["alt"] = ""
+        node["zoom"] = "zoom" in self.options
+        node["zoom_id"] = ""
+
+        self.add_name(node)
+
+        return [node]
+
+    def _get_code(self) -> str:
+        """Get Mermaid code from directive content."""
+        return "\n".join(self.content)

--- a/src/sphinx_oceanid/visitors.py
+++ b/src/sphinx_oceanid/visitors.py
@@ -1,0 +1,47 @@
+"""HTML visitor functions for mermaid_node."""
+
+from __future__ import annotations
+
+import html
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sphinx.writers.html5 import HTML5Translator
+
+    from .nodes import mermaid_node
+
+
+def html_visit_mermaid(self: HTML5Translator, node: mermaid_node) -> None:
+    """Generate opening HTML for a Mermaid diagram.
+
+    Outputs ``<div class="oceanid-diagram" data-oceanid-code="...">``
+    with ``<noscript>`` for accessibility (FR-011, FR-020).
+    """
+    code: str = node["code"]
+
+    classes = ["oceanid-diagram"]
+    align: str = node.get("align", "")
+    if align:
+        classes.append(f"align-{align}")
+
+    attrs: list[str] = [f'class="{" ".join(classes)}"']
+
+    ids: list[str] = node.get("ids", [])
+    if ids:
+        attrs.append(f'id="{html.escape(ids[0], quote=True)}"')
+
+    # FR-020: XSS-safe data attribute
+    attrs.append(f'data-oceanid-code="{html.escape(code, quote=True)}"')
+
+    if node.get("zoom", False):
+        attrs.append("data-oceanid-zoom")
+
+    self.body.append(f"<div {' '.join(attrs)}>\n")
+
+    # FR-011: noscript for accessibility
+    self.body.append(f"<noscript><pre>{html.escape(code)}</pre></noscript>\n")
+
+
+def html_depart_mermaid(self: HTML5Translator, node: mermaid_node) -> None:
+    """Generate closing HTML for a Mermaid diagram."""
+    self.body.append("</div>\n")


### PR DESCRIPTION
## Summary
Add foundational implementations of core Python modules (directives, visitors, assets) and integrate them into the Sphinx extension entry point. These modules provide:
- Directive parsing and docutils node creation
- HTML visitor for rendering mermaid diagrams
- Per-page JS/CSS asset injection via Sphinx event handlers

Closes #4

## Test plan
- All tests pass: `uv --directory /home/driller/repo/sphinx-oceanid run pytest`
- Quality checks pass: `ruff check --fix . && ruff format . && mypy .`
- Build tests verify Sphinx integration points are correctly registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)