### PR TITLE
feat: Add static JavaScript and CSS assets for oceanid extension

### DIFF
--- a/src/sphinx_oceanid/__init__.py
+++ b/src/sphinx_oceanid/__init__.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 __version__ = "0.1.0"
+
+_STATIC_DIR = str(Path(__file__).parent / "_static")
 
 
 def setup(app: Sphinx) -> dict[str, bool | str]:
@@ -25,5 +28,11 @@ def setup(app: Sphinx) -> dict[str, bool | str]:
     app.add_node(mermaid_node, html=(html_visit_mermaid, html_depart_mermaid))
     app.add_directive("mermaid", Mermaid)
     app.connect("html-page-context", install_assets)
+    app.connect("builder-inited", _register_static_path)
 
     return {"version": __version__, "parallel_read_safe": True}
+
+
+def _register_static_path(app: Sphinx) -> None:
+    """Register the extension's _static directory for file copying."""
+    app.config.html_static_path.append(_STATIC_DIR)

--- a/src/sphinx_oceanid/_static/oceanid-observer.js
+++ b/src/sphinx_oceanid/_static/oceanid-observer.js
@@ -1,0 +1,97 @@
+/**
+ * sphinx-oceanid: Diagram rendering and lazy loading via IntersectionObserver.
+ *
+ * Exports:
+ *   renderVisibleDiagrams(elements, renderFn, themeColors)
+ *   setupLazyRendering(elements, renderFn, themeColors)
+ */
+
+/**
+ * Render a single diagram element.
+ *
+ * On success: inserts SVG in .oceanid-svg-container, sets data-oceanid-rendered="true".
+ * On failure (FR-023): sets data-oceanid-render-failed="true", shows error message + source code.
+ *
+ * @param {Element} el - .oceanid-diagram element
+ * @param {Function} renderFn - beautiful-mermaid renderMermaidSVG function
+ * @param {object} themeColors - DiagramColors object
+ */
+const renderSingleDiagram = (el, renderFn, themeColors) => {
+  try {
+    const code = el.getAttribute("data-oceanid-code");
+    if (!code) {
+      throw new Error("data-oceanid-code attribute is missing");
+    }
+
+    const svg = renderFn(code, { ...themeColors });
+
+    const container = document.createElement("div");
+    container.className = "oceanid-svg-container";
+    container.innerHTML = svg;
+
+    el.appendChild(container);
+    el.setAttribute("data-oceanid-rendered", "true");
+  } catch (error) {
+    el.setAttribute("data-oceanid-render-failed", "true");
+
+    const code = el.getAttribute("data-oceanid-code") || "";
+
+    const errorDiv = document.createElement("div");
+    errorDiv.className = "oceanid-render-error";
+    errorDiv.textContent = `Rendering failed: ${error.message}`;
+
+    const sourcePre = document.createElement("pre");
+    sourcePre.className = "oceanid-render-error-source";
+    sourcePre.textContent = code;
+
+    el.appendChild(errorDiv);
+    el.appendChild(sourcePre);
+
+    console.error("sphinx-oceanid: Diagram rendering failed:", error);
+  }
+};
+
+/**
+ * Render all visible diagram elements immediately.
+ *
+ * @param {Element[]} elements - Visible .oceanid-diagram elements
+ * @param {Function} renderFn - beautiful-mermaid renderMermaidSVG function
+ * @param {object} themeColors - DiagramColors object
+ */
+export const renderVisibleDiagrams = (elements, renderFn, themeColors) => {
+  elements.forEach((el) => {
+    renderSingleDiagram(el, renderFn, themeColors);
+  });
+};
+
+/**
+ * Set up IntersectionObserver for lazy rendering of hidden diagram elements.
+ *
+ * Each element gets data-oceanid-deferred="true" while waiting.
+ * Once visible (threshold 0.01), it is rendered and unobserved.
+ *
+ * @param {Element[]} elements - Hidden .oceanid-diagram elements
+ * @param {Function} renderFn - beautiful-mermaid renderMermaidSVG function
+ * @param {object} themeColors - DiagramColors object
+ */
+export const setupLazyRendering = (elements, renderFn, themeColors) => {
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (
+          entry.isIntersecting &&
+          !entry.target.hasAttribute("data-oceanid-rendered")
+        ) {
+          renderSingleDiagram(entry.target, renderFn, themeColors);
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.01 }
+  );
+
+  elements.forEach((el) => {
+    el.setAttribute("data-oceanid-deferred", "true");
+    observer.observe(el);
+  });
+};

--- a/src/sphinx_oceanid/_static/oceanid-renderer.js
+++ b/src/sphinx_oceanid/_static/oceanid-renderer.js
@@ -1,0 +1,102 @@
+/**
+ * sphinx-oceanid: Main entry point for client-side Mermaid rendering.
+ *
+ * Loads config from #oceanid-config, dynamically imports beautiful-mermaid,
+ * resolves theme colors, partitions diagrams by visibility, and delegates
+ * rendering to oceanid-observer.js.
+ */
+
+/**
+ * Load configuration from the #oceanid-config JSON script element.
+ *
+ * @returns {object} Parsed config object
+ * @throws {Error} If #oceanid-config element is not found
+ */
+const loadConfig = () => {
+  const el = document.getElementById("oceanid-config");
+  if (!el || !el.textContent) {
+    throw new Error("oceanid-config element not found");
+  }
+  return JSON.parse(el.textContent);
+};
+
+/**
+ * Partition diagram elements into visible and hidden groups.
+ *
+ * Uses offsetParent and getClientRects() to determine visibility.
+ * Hidden elements will be lazily rendered via IntersectionObserver.
+ *
+ * @param {NodeList|Element[]} elements - .oceanid-diagram elements
+ * @returns {{visible: Element[], hidden: Element[]}}
+ */
+const partitionByVisibility = (elements) => {
+  const visible = [];
+  const hidden = [];
+
+  elements.forEach((el) => {
+    if (el.offsetParent === null || el.getClientRects().length === 0) {
+      hidden.push(el);
+    } else {
+      visible.push(el);
+    }
+  });
+
+  return { visible, hidden };
+};
+
+/**
+ * Resolve theme colors from config and beautiful-mermaid THEMES.
+ *
+ * When theme is "auto", uses themeLight as default.
+ * Full dark/light auto-detection is handled by oceanid-theme.js (T025).
+ *
+ * @param {object} config - Oceanid config object
+ * @param {object} THEMES - beautiful-mermaid THEMES map
+ * @returns {object} DiagramColors object for renderMermaidSVG
+ */
+const resolveThemeColors = (config, THEMES) => {
+  const themeName =
+    config.theme === "auto" ? config.themeLight : config.theme;
+  const colors = THEMES[themeName];
+  if (!colors) {
+    console.warn(
+      `sphinx-oceanid: Theme "${themeName}" not found, using first available theme`
+    );
+    const firstKey = Object.keys(THEMES)[0];
+    return THEMES[firstKey];
+  }
+  return colors;
+};
+
+/**
+ * Main entry point. Runs on window load.
+ */
+const main = async () => {
+  try {
+    const config = loadConfig();
+
+    const beautifulMermaid = await import(config.beautifulMermaidUrl);
+    const renderFn = beautifulMermaid.renderMermaidSVG;
+    const THEMES = beautifulMermaid.THEMES;
+
+    const themeColors = resolveThemeColors(config, THEMES);
+
+    const { renderVisibleDiagrams, setupLazyRendering } = await import(
+      "./oceanid-observer.js"
+    );
+
+    const diagrams = document.querySelectorAll(".oceanid-diagram");
+    if (diagrams.length === 0) {
+      return;
+    }
+
+    const { visible, hidden } = partitionByVisibility(diagrams);
+
+    renderVisibleDiagrams(visible, renderFn, themeColors);
+    setupLazyRendering(hidden, renderFn, themeColors);
+  } catch (err) {
+    console.error("sphinx-oceanid: Failed to initialize:", err);
+  }
+};
+
+window.addEventListener("load", main);

--- a/src/sphinx_oceanid/_static/oceanid.css
+++ b/src/sphinx_oceanid/_static/oceanid.css
@@ -1,0 +1,104 @@
+/* sphinx-oceanid: Styles for Mermaid diagram rendering */
+
+/* Base layout */
+.oceanid-diagram {
+  display: block;
+  width: var(--oceanid-width, 100%);
+  margin: 1rem 0;
+}
+
+.oceanid-diagram .oceanid-svg-container {
+  width: 100%;
+}
+
+.oceanid-diagram .oceanid-svg-container svg {
+  width: 100%;
+  height: var(--oceanid-height, auto);
+  max-width: 100%;
+  display: block;
+}
+
+/* Alignment */
+.oceanid-diagram.align-center {
+  text-align: center;
+}
+
+.oceanid-diagram.align-left {
+  text-align: left;
+}
+
+.oceanid-diagram.align-right {
+  text-align: right;
+}
+
+/* Hide noscript after successful render */
+.oceanid-diagram[data-oceanid-rendered="true"] noscript {
+  display: none;
+}
+
+/* Unsupported diagram type */
+.oceanid-unsupported {
+  border: 2px dashed #e74c3c;
+  padding: 1rem;
+  margin: 1rem 0;
+  border-radius: 4px;
+  background: #fdf2f2;
+}
+
+.oceanid-unsupported-message {
+  color: #e74c3c;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.oceanid-unsupported-code {
+  background: #f8f8f8;
+  padding: 0.5rem;
+  border-radius: 2px;
+  overflow-x: auto;
+  font-family: monospace;
+  font-size: 0.9em;
+}
+
+/* Render error (FR-023) */
+.oceanid-render-error {
+  color: #e74c3c;
+  background: #fff5f5;
+  padding: 1rem;
+  font-family: monospace;
+  font-size: 0.9em;
+  border: 1px solid #e74c3c;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+}
+
+.oceanid-render-error-source {
+  background: #f8f8f8;
+  padding: 0.5rem;
+  border-radius: 2px;
+  overflow-x: auto;
+  font-family: monospace;
+  font-size: 0.85em;
+  border: 1px solid #ddd;
+}
+
+/* JS module load failure source display (FR-024) */
+.oceanid-source-display {
+  background: #f5f5f5;
+  padding: 1rem;
+  border-radius: 4px;
+  border-left: 4px solid #3498db;
+  overflow-x: auto;
+  font-family: monospace;
+  font-size: 0.9em;
+  margin: 1rem 0;
+}
+
+/* Zoom cursor */
+.oceanid-diagram[data-oceanid-zoom] svg {
+  cursor: grab;
+}
+
+.oceanid-diagram[data-oceanid-zoom] svg:active {
+  cursor: grabbing;
+}

--- a/tests/test_static_files.py
+++ b/tests/test_static_files.py
@@ -1,0 +1,164 @@
+"""Tests for static JS/CSS files (T019, T020, T021)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+
+class TestStaticFilesCopied:
+    """Verify static files are copied to build output."""
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_renderer_js_in_output(self, app: Sphinx, build_all: None) -> None:
+        """oceanid-renderer.js is copied to _static in build output."""
+        renderer_js = app.outdir / "_static" / "oceanid-renderer.js"
+        assert renderer_js.exists()
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_observer_js_in_output(self, app: Sphinx, build_all: None) -> None:
+        """oceanid-observer.js is copied to _static in build output."""
+        observer_js = app.outdir / "_static" / "oceanid-observer.js"
+        assert observer_js.exists()
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_css_in_output(self, app: Sphinx, build_all: None) -> None:
+        """oceanid.css is copied to _static in build output."""
+        css = app.outdir / "_static" / "oceanid.css"
+        assert css.exists()
+
+
+class TestOceanidCssContent:
+    """Verify CSS contains expected selectors (T021)."""
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_diagram_base_class(self, app: Sphinx, build_all: None) -> None:
+        """CSS defines .oceanid-diagram base styles."""
+        css = (app.outdir / "_static" / "oceanid.css").read_text()
+        assert ".oceanid-diagram" in css
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_svg_container_class(self, app: Sphinx, build_all: None) -> None:
+        """CSS defines .oceanid-svg-container styles."""
+        css = (app.outdir / "_static" / "oceanid.css").read_text()
+        assert ".oceanid-svg-container" in css
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_align_classes(self, app: Sphinx, build_all: None) -> None:
+        """CSS defines alignment classes."""
+        css = (app.outdir / "_static" / "oceanid.css").read_text()
+        assert ".align-center" in css
+        assert ".align-left" in css
+        assert ".align-right" in css
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_render_error_classes(self, app: Sphinx, build_all: None) -> None:
+        """CSS defines render error styles (FR-023)."""
+        css = (app.outdir / "_static" / "oceanid.css").read_text()
+        assert ".oceanid-render-error" in css
+        assert ".oceanid-render-error-source" in css
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_source_display_class(self, app: Sphinx, build_all: None) -> None:
+        """CSS defines source display styles (FR-024)."""
+        css = (app.outdir / "_static" / "oceanid.css").read_text()
+        assert ".oceanid-source-display" in css
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_unsupported_classes(self, app: Sphinx, build_all: None) -> None:
+        """CSS defines unsupported diagram styles."""
+        css = (app.outdir / "_static" / "oceanid.css").read_text()
+        assert ".oceanid-unsupported" in css
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_noscript_hiding(self, app: Sphinx, build_all: None) -> None:
+        """CSS hides noscript when rendered."""
+        css = (app.outdir / "_static" / "oceanid.css").read_text()
+        assert "data-oceanid-rendered" in css
+        assert "noscript" in css
+
+
+class TestRendererJsContent:
+    """Verify renderer.js contains expected structure (T019)."""
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_load_config_function(self, app: Sphinx, build_all: None) -> None:
+        """renderer.js defines loadConfig function."""
+        js = (app.outdir / "_static" / "oceanid-renderer.js").read_text()
+        assert "loadConfig" in js
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_partition_by_visibility(self, app: Sphinx, build_all: None) -> None:
+        """renderer.js defines partitionByVisibility function."""
+        js = (app.outdir / "_static" / "oceanid-renderer.js").read_text()
+        assert "partitionByVisibility" in js
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_imports_observer(self, app: Sphinx, build_all: None) -> None:
+        """renderer.js imports from oceanid-observer.js."""
+        js = (app.outdir / "_static" / "oceanid-renderer.js").read_text()
+        assert "oceanid-observer.js" in js
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_oceanid_config_element(self, app: Sphinx, build_all: None) -> None:
+        """renderer.js reads from #oceanid-config element."""
+        js = (app.outdir / "_static" / "oceanid-renderer.js").read_text()
+        assert "oceanid-config" in js
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_window_load_listener(self, app: Sphinx, build_all: None) -> None:
+        """renderer.js attaches to window load event."""
+        js = (app.outdir / "_static" / "oceanid-renderer.js").read_text()
+        assert "load" in js
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_es_module_format(self, app: Sphinx, build_all: None) -> None:
+        """renderer.js uses ES module import syntax."""
+        js = (app.outdir / "_static" / "oceanid-renderer.js").read_text()
+        assert "import" in js
+
+
+class TestObserverJsContent:
+    """Verify observer.js contains expected structure (T020)."""
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_render_visible_diagrams_export(self, app: Sphinx, build_all: None) -> None:
+        """observer.js exports renderVisibleDiagrams."""
+        js = (app.outdir / "_static" / "oceanid-observer.js").read_text()
+        assert "renderVisibleDiagrams" in js
+        assert "export" in js
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_setup_lazy_rendering_export(self, app: Sphinx, build_all: None) -> None:
+        """observer.js exports setupLazyRendering."""
+        js = (app.outdir / "_static" / "oceanid-observer.js").read_text()
+        assert "setupLazyRendering" in js
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_intersection_observer_usage(self, app: Sphinx, build_all: None) -> None:
+        """observer.js uses IntersectionObserver for lazy rendering."""
+        js = (app.outdir / "_static" / "oceanid-observer.js").read_text()
+        assert "IntersectionObserver" in js
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_render_error_handling(self, app: Sphinx, build_all: None) -> None:
+        """observer.js handles render errors (FR-023)."""
+        js = (app.outdir / "_static" / "oceanid-observer.js").read_text()
+        assert "data-oceanid-render-failed" in js
+        assert "oceanid-render-error" in js
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_data_attribute_state_management(self, app: Sphinx, build_all: None) -> None:
+        """observer.js manages data-oceanid-rendered attribute."""
+        js = (app.outdir / "_static" / "oceanid-observer.js").read_text()
+        assert "data-oceanid-rendered" in js
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_data_deferred_attribute(self, app: Sphinx, build_all: None) -> None:
+        """observer.js sets data-oceanid-deferred attribute."""
+        js = (app.outdir / "_static" / "oceanid-observer.js").read_text()
+        assert "data-oceanid-deferred" in js


### PR DESCRIPTION
## Summary
- Implement core static assets (oceanid-renderer.js, oceanid-observer.js, oceanid.css) for the sphinx-oceanid extension
- Register _static directory in __init__.py via builder-inited event for proper file copying during Sphinx build
- Add comprehensive test suite to verify asset presence and basic validity checks

## Test plan
- Run test suite: `uv --directory /home/driller/repo/sphinx-oceanid run pytest tests/test_static_files.py -v`
- Verify static files are copied to HTML build output
- Test that assets are properly registered when building documentation

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)