### PR TITLE
test: Add MyST Markdown integration tests for mermaid support

### DIFF
--- a/tests/roots/test-markdown/conf.py
+++ b/tests/roots/test-markdown/conf.py
@@ -1,0 +1,3 @@
+extensions = ["sphinx_oceanid", "myst_parser"]
+exclude_patterns = ["_build"]
+myst_fence_as_directive = ["mermaid"]

--- a/tests/roots/test-markdown/index.md
+++ b/tests/roots/test-markdown/index.md
@@ -1,0 +1,10 @@
+# Test
+
+```mermaid
+---
+name: test-diagram
+align: center
+---
+sequenceDiagram
+  Alice->>Bob: Hello
+```

--- a/tests/test_integration_html.py
+++ b/tests/test_integration_html.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import html
+import re
 from typing import TYPE_CHECKING
 
 import pytest
@@ -36,3 +38,74 @@ class TestHtmlIntegration:
     def test_html_contains_css(self, app: Sphinx, index: str) -> None:
         """Output HTML references oceanid.css."""
         assert "oceanid.css" in index
+
+
+def _extract_oceanid_divs(html_content: str) -> list[str]:
+    """Extract all oceanid-diagram div opening tags from HTML content."""
+    return re.findall(r'<div [^>]*class="[^"]*oceanid-diagram[^"]*"[^>]*>', html_content)
+
+
+class TestMarkdownIntegration:
+    """Integration tests for MyST Markdown input (US2).
+
+    Verifies that MyST fenced mermaid blocks produce functionally
+    equivalent HTML to RST directives via myst_fence_as_directive.
+    """
+
+    @pytest.mark.sphinx("html", testroot="markdown")
+    def test_markdown_build_succeeds(self, app: Sphinx, build_all: None) -> None:
+        """MyST Markdown build completes with mermaid fenced blocks."""
+        assert (app.outdir / "index.html").exists()
+
+    @pytest.mark.sphinx("html", testroot="markdown")
+    def test_markdown_contains_oceanid_diagram(self, app: Sphinx, index: str) -> None:
+        """MyST fenced mermaid blocks produce oceanid-diagram elements."""
+        assert "oceanid-diagram" in index
+
+    @pytest.mark.sphinx("html", testroot="markdown")
+    def test_markdown_diagram_has_align(self, app: Sphinx, index: str) -> None:
+        """MyST fenced mermaid block with align option produces align class."""
+        assert "align-center" in index
+
+    @pytest.mark.sphinx("html", testroot="markdown")
+    def test_markdown_diagram_has_name(self, app: Sphinx, index: str) -> None:
+        """MyST fenced mermaid block with name option produces id attribute."""
+        assert 'id="test-diagram"' in index
+
+    @pytest.mark.sphinx("html", testroot="markdown")
+    def test_markdown_diagram_has_data_code(self, app: Sphinx, index: str) -> None:
+        """MyST fenced mermaid block content is in data-oceanid-code attribute."""
+        escaped_code = html.escape("sequenceDiagram\n  Alice->>Bob: Hello", quote=True)
+        assert f'data-oceanid-code="{escaped_code}"' in index
+
+    @pytest.mark.sphinx("html", testroot="markdown")
+    def test_markdown_contains_renderer_js(self, app: Sphinx, index: str) -> None:
+        """MyST Markdown output references oceanid-renderer.js."""
+        assert "oceanid-renderer.js" in index
+
+    @pytest.mark.sphinx("html", testroot="markdown")
+    def test_markdown_contains_css(self, app: Sphinx, index: str) -> None:
+        """MyST Markdown output references oceanid.css."""
+        assert "oceanid.css" in index
+
+    @pytest.mark.sphinx("html", testroot="markdown")
+    def test_markdown_equivalent_to_rst(self, app: Sphinx, index: str) -> None:
+        """MyST output is functionally equivalent to RST output.
+
+        Checks that the same structural elements are present:
+        - oceanid-diagram class
+        - align-center class
+        - id from name option
+        - data-oceanid-code with diagram content
+        - noscript accessibility element
+        """
+        divs = _extract_oceanid_divs(index)
+        assert len(divs) >= 1, "Expected at least one oceanid-diagram div"
+
+        first_div = divs[0]
+        assert "oceanid-diagram" in first_div
+        assert "align-center" in first_div
+        assert 'id="test-diagram"' in first_div
+        assert "data-oceanid-code=" in first_div
+
+        assert "<noscript>" in index


### PR DESCRIPTION
## Summary

Adds comprehensive test suite for MyST Markdown support (US2), verifying that MyST fenced mermaid blocks produce functionally equivalent oceanid-diagram HTML output to RST directives. Includes tests for diagram rendering, alignment, naming, and complete feature parity via myst_fence_as_directive.

Closes #6

## Test plan

- [x] All 99 existing tests pass
- [x] Quality checks passed (ruff, mypy)
- [x] New markdown test root created with conf.py and index.md
- [x] 8 new test cases verify MyST/RST equivalence
- [x] Manual verification: diagram rendering, alignment classes, id attributes, data-oceanid-code attributes, accessibility elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)