### PR TITLE
docs: Create comprehensive README and Japanese translation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,130 @@
+# sphinx-oceanid
+
+[beautiful-mermaid](https://github.com/niccolozy/beautiful-mermaid) を活用した、Sphinx 向け高品質 Mermaid ダイアグラム拡張機能。
+
+## 特徴
+
+- **beautiful-mermaid レンダリング** — ELK.js ベースのレイアウトエンジンによる高品質 SVG 出力
+- **CSS 変数テーマ** — ダーク/ライトテーマの自動検出と即時切替（再レンダリング不要）
+- **ゼロコンフィグ** — CDN 配信の beautiful-mermaid で追加設定なしに動作
+- **sphinx-revealjs 対応** — IntersectionObserver による非表示スライドの遅延レンダリング
+- **パン＆ズーム** — ネイティブ Pointer Events + SVG transform を使用（d3.js 不要）
+- **フルスクリーンモーダル** — ビューポートサイズのオーバーレイでダイアグラムを表示
+- **外部ファイル対応** — インラインコードの代わりに `.mmd` ファイルを参照可能
+- **クラスダイアグラム自動生成** — Python コードからクラス階層図を自動生成
+
+## 対応ダイアグラムタイプ
+
+| タイプ | エイリアス |
+|--------|------------|
+| `flowchart` | `graph` |
+| `sequenceDiagram` | |
+| `classDiagram` | |
+| `stateDiagram` | `stateDiagram-v2` |
+| `erDiagram` | |
+| `xychart-beta` | |
+
+非対応のダイアグラムタイプには明示的な警告（またはエラー）が出力されます。無音での劣化は発生しません。
+
+## インストール
+
+sphinx-oceanid は Python 3.13 以上が必要です。
+
+GitHub から直接インストール：
+
+```bash
+pip install git+https://github.com/drillan/sphinx-oceanid.git
+```
+
+またはリポジトリをクローンしてローカルインストール：
+
+```bash
+git clone https://github.com/drillan/sphinx-oceanid.git
+cd sphinx-oceanid
+pip install .
+```
+
+## クイックスタート
+
+`conf.py` に拡張機能を追加します：
+
+```python
+extensions = ["sphinx_oceanid"]
+```
+
+reStructuredText ファイルで `mermaid` ディレクティブを使用します：
+
+```rst
+.. mermaid::
+
+   flowchart LR
+     A[開始] --> B[処理] --> C[終了]
+```
+
+Markdown（MyST）ファイルの場合：
+
+````markdown
+```{mermaid}
+sequenceDiagram
+  Alice->>Bob: Hello
+  Bob-->>Alice: Hi!
+```
+````
+
+## 設定
+
+すべての設定オプションは `conf.py` で `oceanid_` プレフィックスを使用します：
+
+```python
+# conf.py
+extensions = ["sphinx_oceanid"]
+
+# テーマ（デフォルト: "auto" — Sphinx テーマからダーク/ライトを検出）
+oceanid_theme = "auto"
+oceanid_theme_dark = "zinc-dark"
+oceanid_theme_light = "zinc-light"
+
+# 全ダイアグラムでズームを有効化（デフォルト: False）
+oceanid_zoom = True
+
+# フルスクリーンモーダルを有効化（デフォルト: False）
+oceanid_fullscreen = True
+
+# 非対応ダイアグラムタイプへの対応: "warning" または "error"（デフォルト: "warning"）
+oceanid_unsupported_action = "warning"
+```
+
+## ディレクティブオプション
+
+```rst
+.. mermaid::
+   :name: my-diagram
+   :alt: アクセシビリティ用の説明文
+   :align: center
+   :caption: ダイアグラムのキャプション（<figcaption> としてレンダリング）
+   :title: Mermaid ネイティブタイトル（ダイアグラム内部に表示）
+   :zoom:
+   :config: {"theme": "forest"}
+
+   flowchart LR
+     A --> B --> C
+```
+
+## クラスダイアグラム自動生成
+
+Python コードからクラス階層図を自動生成します：
+
+```rst
+.. autoclasstree:: mypackage.MyClass
+   :full:
+   :namespace: mypackage
+   :caption: クラス階層
+```
+
+## ドキュメント
+
+詳細なドキュメントは [docs/](docs/) ディレクトリを参照してください。
+
+## ライセンス
+
+BSD-3-Clause。詳細は [LICENSE](LICENSE) を参照してください。

--- a/README.md
+++ b/README.md
@@ -1,0 +1,130 @@
+# sphinx-oceanid
+
+High-quality Mermaid diagrams in Sphinx, powered by [beautiful-mermaid](https://github.com/niccolozy/beautiful-mermaid).
+
+## Features
+
+- **beautiful-mermaid rendering** — Uses ELK.js-based layout engine for high-quality SVG output
+- **CSS variable theming** — Automatic dark/light theme detection with instant switching (no re-render)
+- **Zero-config** — Works out of the box with CDN-hosted beautiful-mermaid
+- **sphinx-revealjs support** — Lazy rendering for hidden slides via IntersectionObserver
+- **Pan & zoom** — Native Pointer Events + SVG transform (no d3.js dependency)
+- **Fullscreen modal** — View diagrams in a viewport-sized overlay
+- **External file support** — Reference `.mmd` files instead of inline code
+- **Auto class diagrams** — Generate class hierarchy diagrams from Python code
+
+## Supported Diagram Types
+
+| Type | Alias |
+|------|-------|
+| `flowchart` | `graph` |
+| `sequenceDiagram` | |
+| `classDiagram` | |
+| `stateDiagram` | `stateDiagram-v2` |
+| `erDiagram` | |
+| `xychart-beta` | |
+
+Unsupported diagram types produce explicit warnings (or errors), never silent degradation.
+
+## Installation
+
+sphinx-oceanid requires Python 3.13+.
+
+From GitHub:
+
+```bash
+pip install git+https://github.com/drillan/sphinx-oceanid.git
+```
+
+Or clone and install locally:
+
+```bash
+git clone https://github.com/drillan/sphinx-oceanid.git
+cd sphinx-oceanid
+pip install .
+```
+
+## Quick Start
+
+Add the extension to your `conf.py`:
+
+```python
+extensions = ["sphinx_oceanid"]
+```
+
+Then use the `mermaid` directive in your reStructuredText files:
+
+```rst
+.. mermaid::
+
+   flowchart LR
+     A[Start] --> B[Process] --> C[End]
+```
+
+Or in Markdown (MyST) files:
+
+````markdown
+```{mermaid}
+sequenceDiagram
+  Alice->>Bob: Hello
+  Bob-->>Alice: Hi!
+```
+````
+
+## Configuration
+
+All configuration options use the `oceanid_` prefix in `conf.py`:
+
+```python
+# conf.py
+extensions = ["sphinx_oceanid"]
+
+# Theme (default: "auto" — detects dark/light from Sphinx theme)
+oceanid_theme = "auto"
+oceanid_theme_dark = "zinc-dark"
+oceanid_theme_light = "zinc-light"
+
+# Enable zoom on all diagrams (default: False)
+oceanid_zoom = True
+
+# Enable fullscreen modal (default: False)
+oceanid_fullscreen = True
+
+# Action for unsupported diagram types: "warning" or "error" (default: "warning")
+oceanid_unsupported_action = "warning"
+```
+
+## Directive Options
+
+```rst
+.. mermaid::
+   :name: my-diagram
+   :alt: Description for accessibility
+   :align: center
+   :caption: Diagram caption (rendered as <figcaption>)
+   :title: Mermaid native title (rendered inside the diagram)
+   :zoom:
+   :config: {"theme": "forest"}
+
+   flowchart LR
+     A --> B --> C
+```
+
+## Auto Class Diagrams
+
+Generate class hierarchy diagrams from Python code:
+
+```rst
+.. autoclasstree:: mypackage.MyClass
+   :full:
+   :namespace: mypackage
+   :caption: Class hierarchy
+```
+
+## Documentation
+
+Full documentation is available in the [docs/](docs/) directory.
+
+## License
+
+BSD-3-Clause. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

- Add English README.md with feature overview, installation instructions, supported diagram types, and usage examples
- Add Japanese translation (README.ja.md) to serve non-English speaking users
- Documents sphinx-oceanid's key differentiators: beautiful-mermaid rendering, CSS variable theming, zero-config setup, and lazy rendering support

Closes #29

## Test plan

- [x] Quality checks pass (ruff, mypy)
- [x] Both README files created with complete content
- [x] Markdown formatting verified (headers, tables, code blocks)
- [x] Links and references are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)