### PR TITLE
docs: Add live-rendered Mermaid diagram examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ author = "driller"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["myst_parser"]
+extensions = ["myst_parser", "sphinx_oceanid"]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,11 @@ Write Mermaid code directly in the directive body:
      A --> B --> C
 ````
 
+```{mermaid}
+flowchart LR
+  A --> B --> C
+```
+
 ### External files
 
 Reference an external `.mmd` file instead of inline code. The path is relative to the Sphinx source directory.
@@ -47,6 +52,13 @@ Provides accessibility text for the diagram. Rendered as an `aria-label` attribu
      Alice->>Bob: Hello
 ````
 
+```{mermaid}
+:alt: Sequence diagram showing Alice greeting Bob
+
+sequenceDiagram
+  Alice->>Bob: Hello
+```
+
 ### `:caption:` — Figure caption
 
 Wraps the diagram in an HTML `<figure>` element with a `<figcaption>`. Supports inline markup and cross-references via `:name:`.
@@ -60,6 +72,14 @@ Wraps the diagram in an HTML `<figure>` element with a `<figcaption>`. Supports 
      A --> B --> C
 ````
 
+```{mermaid}
+:caption: System architecture overview
+:name: fig-architecture-demo
+
+flowchart LR
+  A --> B --> C
+```
+
 ### `:zoom:` — Enable zoom
 
 Enables pan-and-zoom interaction on a specific diagram. Uses native Pointer Events + SVG transform (no d3.js).
@@ -71,6 +91,13 @@ Enables pan-and-zoom interaction on a specific diagram. Uses native Pointer Even
    classDiagram
      Animal <|-- Duck
 ````
+
+```{mermaid}
+:zoom:
+
+classDiagram
+  Animal <|-- Duck
+```
 
 ### `:config:` — Mermaid configuration
 
@@ -84,6 +111,13 @@ Injects a JSON configuration object into the Mermaid frontmatter. Allows per-dia
      A --> B
 ````
 
+```{mermaid}
+:config: {"theme": "forest"}
+
+flowchart LR
+  A --> B
+```
+
 ### `:title:` — Mermaid native title
 
 Inserts a title into the Mermaid frontmatter. Unlike `:caption:` (which renders outside the diagram as `<figcaption>`), `:title:` is rendered inside the diagram by Mermaid itself.
@@ -95,6 +129,13 @@ Inserts a title into the Mermaid frontmatter. Unlike `:caption:` (which renders 
    flowchart LR
      A --> B --> C
 ````
+
+```{mermaid}
+:title: Processing Flow
+
+flowchart LR
+  A --> B --> C
+```
 
 ### Combined example
 
@@ -113,6 +154,19 @@ All options can be used together:
    flowchart LR
      Input --> Process --> Output
 ````
+
+```{mermaid}
+:name: my-diagram-demo
+:alt: Flow showing data processing pipeline
+:align: center
+:caption: Data Processing Pipeline
+:zoom:
+:config: {"theme": "forest"}
+:title: Pipeline Overview
+
+flowchart LR
+  Input --> Process --> Output
+```
 
 ## Auto-generated Class Diagrams
 

--- a/docs/supported-diagrams.md
+++ b/docs/supported-diagrams.md
@@ -27,6 +27,13 @@ sphinx-oceanid uses [beautiful-mermaid](https://github.com/niccolozy/beautiful-m
      B -->|No| D[Cancel]
 ````
 
+```{mermaid}
+flowchart LR
+  A[Start] --> B{Decision}
+  B -->|Yes| C[OK]
+  B -->|No| D[Cancel]
+```
+
 The `graph` keyword is an alias for `flowchart`:
 
 ````rst
@@ -36,6 +43,12 @@ The `graph` keyword is an alias for `flowchart`:
      A --> B
      B --> C
 ````
+
+```{mermaid}
+graph TD
+  A --> B
+  B --> C
+```
 
 ### sequenceDiagram
 
@@ -51,6 +64,16 @@ The `graph` keyword is an alias for `flowchart`:
      Bob-->>Alice: Fine, thanks!
 ````
 
+```{mermaid}
+sequenceDiagram
+  participant Alice
+  participant Bob
+  Alice->>Bob: Hello Bob
+  Bob-->>Alice: Hi Alice
+  Alice->>Bob: How are you?
+  Bob-->>Alice: Fine, thanks!
+```
+
 ### classDiagram
 
 ````rst
@@ -64,6 +87,16 @@ The `graph` keyword is an alias for `flowchart`:
      Duck : +swim()
      Fish : +swim()
 ````
+
+```{mermaid}
+classDiagram
+  Animal <|-- Duck
+  Animal <|-- Fish
+  Animal : +String name
+  Animal : +move()
+  Duck : +swim()
+  Fish : +swim()
+```
 
 You can also auto-generate class diagrams from Python code using the `autoclasstree` directive. See {doc}`index` for details.
 
@@ -79,6 +112,14 @@ You can also auto-generate class diagrams from Python code using the `autoclasst
      Active --> [*] : quit
 ````
 
+```{mermaid}
+stateDiagram-v2
+  [*] --> Active
+  Active --> Inactive : timeout
+  Inactive --> Active : input
+  Active --> [*] : quit
+```
+
 Both `stateDiagram` and `stateDiagram-v2` keywords are supported.
 
 ### erDiagram
@@ -92,6 +133,13 @@ Both `stateDiagram` and `stateDiagram-v2` keywords are supported.
      PRODUCT ||--o{ LINE-ITEM : "is in"
 ````
 
+```{mermaid}
+erDiagram
+  CUSTOMER ||--o{ ORDER : places
+  ORDER ||--|{ LINE-ITEM : contains
+  PRODUCT ||--o{ LINE-ITEM : "is in"
+```
+
 ### xychart-beta
 
 ````rst
@@ -104,6 +152,15 @@ Both `stateDiagram` and `stateDiagram-v2` keywords are supported.
      bar [1200, 2400, 1800, 3600, 4200]
      line [1200, 2400, 1800, 3600, 4200]
 ````
+
+```{mermaid}
+xychart-beta
+  title "Monthly Sales"
+  x-axis [Jan, Feb, Mar, Apr, May]
+  y-axis "Revenue (USD)" 0 --> 5000
+  bar [1200, 2400, 1800, 3600, 4200]
+  line [1200, 2400, 1800, 3600, 4200]
+```
 
 ## Unsupported diagram types
 


### PR DESCRIPTION
## Summary

- Enable `sphinx_oceanid` extension in `docs/conf.py` to activate live rendering
- Add live-rendered mermaid directive examples alongside RST code blocks in `docs/index.md` for all directive options (basic, alt, caption, zoom, config, title, combined)
- Add live-rendered examples in `docs/supported-diagrams.md` demonstrating all 6 supported diagram types (flowchart, sequenceDiagram, classDiagram, stateDiagram, erDiagram, xychart-beta) plus the graph alias

Closes #39

## Test plan

- [ ] Build documentation locally: `uv --directory . run make -C docs html`
- [ ] Open `docs/_build/html/index.html` and `docs/_build/html/supported-diagrams.html` in browser
- [ ] Verify all live-rendered diagram examples display correctly (not just code blocks)
- [ ] Confirm diagram rendering matches the RST code block examples on the same page
- [ ] Test diagram interactivity features (zoom where enabled)
- [ ] Verify no console errors in browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)