### PR TITLE
feat: enable fullscreen modal and enhance diagram documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,3 +27,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 html_theme = "shibuya"
 language = "en"
 html_static_path = ["_static"]
+
+# -- Options for sphinx-oceanid ------------------------------------------------
+
+oceanid_fullscreen = True

--- a/docs/supported-diagrams.md
+++ b/docs/supported-diagrams.md
@@ -230,9 +230,9 @@ sequenceDiagram
   Bob-->>Alice: Fine, thanks!
 ```
 
-#### Actors, loops, alt blocks, notes, and activation
+#### TCP handshake and connection lifecycle
 
-`actor` declarations, combined control blocks (`loop`, `alt`/`else`), `Note`, activation via `+`/`-` shorthand, and self-messages:
+`participant` aliases, activation via `+`/`-` shorthand, `Note`, `loop`, and `alt`/`else` blocks — modeled on TCP 3-way handshake, data transfer, and connection teardown:
 
 ::::{tab-set}
 :::{tab-item} RST
@@ -241,18 +241,23 @@ sequenceDiagram
 .. mermaid::
 
    sequenceDiagram
-     actor User
+     participant C as Client
      participant S as Server
-     User ->>+ S: Request
-     loop Validate
-       S ->> S: Check input
+     Note over C, S: 3-way handshake
+     C ->>+ S: SYN
+     S -->>- C: SYN-ACK
+     C ->> S: ACK
+     loop Data transfer
+       C ->>+ S: Request
+       alt Success
+         S -->>- C: 200 OK
+       else Error
+         S -->> C: 500
+       end
      end
-     Note right of S: Processing
-     alt Success
-       S ->>- User: 200 OK
-     else Error
-       S -->> User: 500
-     end
+     Note over C, S: Connection teardown
+     C ->> S: FIN
+     S -->> C: FIN-ACK
 ````
 :::
 :::{tab-item} MyST
@@ -260,18 +265,23 @@ sequenceDiagram
 ````markdown
 ```{mermaid}
 sequenceDiagram
-  actor User
+  participant C as Client
   participant S as Server
-  User ->>+ S: Request
-  loop Validate
-    S ->> S: Check input
+  Note over C, S: 3-way handshake
+  C ->>+ S: SYN
+  S -->>- C: SYN-ACK
+  C ->> S: ACK
+  loop Data transfer
+    C ->>+ S: Request
+    alt Success
+      S -->>- C: 200 OK
+    else Error
+      S -->> C: 500
+    end
   end
-  Note right of S: Processing
-  alt Success
-    S ->>- User: 200 OK
-  else Error
-    S -->> User: 500
-  end
+  Note over C, S: Connection teardown
+  C ->> S: FIN
+  S -->> C: FIN-ACK
 ```
 ````
 :::
@@ -279,18 +289,23 @@ sequenceDiagram
 
 ```{mermaid}
 sequenceDiagram
-  actor User
+  participant C as Client
   participant S as Server
-  User ->>+ S: Request
-  loop Validate
-    S ->> S: Check input
+  Note over C, S: 3-way handshake
+  C ->>+ S: SYN
+  S -->>- C: SYN-ACK
+  C ->> S: ACK
+  loop Data transfer
+    C ->>+ S: Request
+    alt Success
+      S -->>- C: 200 OK
+    else Error
+      S -->> C: 500
+    end
   end
-  Note right of S: Processing
-  alt Success
-    S ->>- User: 200 OK
-  else Error
-    S -->> User: 500
-  end
+  Note over C, S: Connection teardown
+  C ->> S: FIN
+  S -->> C: FIN-ACK
 ```
 
 ```{note}
@@ -406,7 +421,39 @@ classDiagram
   Duck ..|> Swimmable
 ```
 
-You can also auto-generate class diagrams from Python code using the `autoclasstree` directive. See {doc}`index` for details.
+#### Auto-generated from Python code
+
+The `autoclasstree` directive generates class diagrams from Python class hierarchies automatically. This example visualizes the Sphinx role class hierarchy:
+
+::::{tab-set}
+:::{tab-item} RST
+:sync: rst
+````rst
+.. autoclasstree:: sphinx.roles
+   :strict:
+   :caption: Sphinx role class hierarchy
+   :zoom:
+````
+:::
+:::{tab-item} MyST
+:sync: myst
+````markdown
+```{autoclasstree} sphinx.roles
+:strict:
+:caption: Sphinx role class hierarchy
+:zoom:
+```
+````
+:::
+::::
+
+```{autoclasstree} sphinx.roles
+:strict:
+:caption: Sphinx role class hierarchy
+:zoom:
+```
+
+See {doc}`index` for full `autoclasstree` options (`:full:`, `:strict:`, `:namespace:`).
 
 ```{note}
 **Known limitations**

--- a/src/sphinx_oceanid/_static/oceanid-fullscreen.js
+++ b/src/sphinx_oceanid/_static/oceanid-fullscreen.js
@@ -81,9 +81,10 @@ const addFullscreenButton = (el, config, modalCtx) => {
     }
     modalCtx.container.innerHTML = "";
     const clone = svg.cloneNode(true);
+    clone.removeAttribute("width");
+    clone.removeAttribute("height");
     clone.style.width = "100%";
-    clone.style.height = "auto";
-    clone.style.maxHeight = "90vh";
+    clone.style.height = "100%";
     modalCtx.container.appendChild(clone);
     modalCtx.modal.classList.add("active");
   });

--- a/src/sphinx_oceanid/_static/oceanid.css
+++ b/src/sphinx_oceanid/_static/oceanid.css
@@ -121,13 +121,18 @@
 }
 
 .oceanid-container-fullscreen {
-  max-width: 95vw;
-  max-height: 90vh;
+  width: 95vw;
+  height: 90vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   overflow: auto;
 }
 
 .oceanid-container-fullscreen svg {
   display: block;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 .oceanid-fullscreen-btn {


### PR DESCRIPTION
## Summary

- Enable fullscreen modal feature in documentation configuration
- Fix SVG scaling in fullscreen mode by removing fixed dimensions and using viewBox-based responsive sizing
- Improve fullscreen modal container layout with flexbox centering
- Enhance supported-diagrams documentation with real-world TCP handshake sequence diagram example
- Add interactive autoclasstree example showcasing auto-generated class hierarchy diagrams from Python code

## Test plan

- [x] Quality checks passed: ruff, mypy, pytest (222 tests)
- [x] Documentation builds successfully with fullscreen enabled
- [x] Fullscreen modal displays diagrams correctly with responsive scaling
- [x] New diagram examples render correctly and are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)