### PR TITLE
feat: support YAML frontmatter in mermaid diagrams

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -16,6 +16,7 @@
 - **パン＆ズーム** — ネイティブ Pointer Events + SVG transform を使用（d3.js 不要）
 - **フルスクリーンモーダル** — ビューポートサイズのオーバーレイでダイアグラムを表示
 - **外部ファイル対応** — インラインコードの代わりに `.mmd` ファイルを参照可能
+- **YAML frontmatter** — `.mmd` ファイルや RST 内で Mermaid frontmatter によるタイトル・設定が可能
 - **クラスダイアグラム自動生成** — Python コードからクラス階層図を自動生成
 
 ## 対応ダイアグラムタイプ
@@ -131,6 +132,25 @@ oceanid_unsupported_action = "warning"
    flowchart LR
      A --> B --> C
 ```
+
+## YAML Frontmatter
+
+外部 `.mmd` ファイルに YAML frontmatter を記述して、ダイアグラムのタイトルや per-diagram レンダリングオプションを設定できます：
+
+```yaml
+---
+title: User Authentication Flow
+config:
+  bg: "#1a1b26"
+  fg: "#a9b1d6"
+---
+flowchart TD
+  A[Login Page] --> B{Valid credentials?}
+  B -->|Yes| C[Dashboard]
+  B -->|No| D[Error Message]
+```
+
+RST インラインコンテンツでも frontmatter を使用できます。MyST Markdown では、`config` に JSON 形式を使用してください。詳細は[ドキュメント](https://drillan.github.io/sphinx-oceanid/)を参照してください。
 
 ## クラスダイアグラム自動生成
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Mermaid diagrams in Sphinx, powered by [beautiful-mermaid](https://github.com/ni
 - **Pan & zoom** — Native Pointer Events + SVG transform (no d3.js dependency)
 - **Fullscreen modal** — View diagrams in a viewport-sized overlay
 - **External file support** — Reference `.mmd` files instead of inline code
+- **YAML frontmatter** — Set title and per-diagram config via Mermaid frontmatter in `.mmd` files and RST
 - **Auto class diagrams** — Generate class hierarchy diagrams from Python code
 
 ## Supported Diagram Types
@@ -131,6 +132,25 @@ oceanid_unsupported_action = "warning"
    flowchart LR
      A --> B --> C
 ```
+
+## YAML Frontmatter
+
+External `.mmd` files can include YAML frontmatter to set the diagram title and per-diagram rendering options:
+
+```yaml
+---
+title: User Authentication Flow
+config:
+  bg: "#1a1b26"
+  fg: "#a9b1d6"
+---
+flowchart TD
+  A[Login Page] --> B{Valid credentials?}
+  B -->|Yes| C[Dashboard]
+  B -->|No| D[Error Message]
+```
+
+Frontmatter is also supported in RST inline content. In MyST Markdown, use directive options with JSON format for `config`. See the [documentation](https://drillan.github.io/sphinx-oceanid/) for details.
 
 ## Auto Class Diagrams
 

--- a/docs/diagrams/auth-flow.mmd
+++ b/docs/diagrams/auth-flow.mmd
@@ -1,0 +1,12 @@
+---
+title: User Authentication Flow
+config:
+  bg: "#1a1b26"
+  fg: "#a9b1d6"
+---
+flowchart TD
+  A[Login Page] --> B{Valid credentials?}
+  B -->|Yes| C[Generate Token]
+  C --> D[Dashboard]
+  B -->|No| E[Show Error]
+  E --> A

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,6 +76,113 @@ All directive options work with external files:
 
 If the file is not found, the build produces an error with the file path and source location.
 
+#### Sample `.mmd` file
+
+External `.mmd` files can include [YAML frontmatter](#yaml-frontmatter) to set the title and per-diagram configuration:
+
+```yaml
+---
+title: User Authentication Flow
+config:
+  bg: "#1a1b26"
+  fg: "#a9b1d6"
+---
+flowchart TD
+  A[Login Page] --> B{Valid credentials?}
+  B -->|Yes| C[Generate Token]
+  C --> D[Dashboard]
+  B -->|No| E[Show Error]
+  E --> A
+```
+
+Reference the file as usual:
+
+::::{tab-set}
+:::{tab-item} RST
+:sync: rst
+````rst
+.. mermaid:: diagrams/auth-flow.mmd
+````
+:::
+:::{tab-item} MyST
+:sync: myst
+````markdown
+```{mermaid} diagrams/auth-flow.mmd
+```
+````
+:::
+::::
+
+```{mermaid} diagrams/auth-flow.mmd
+```
+
+(yaml-frontmatter)=
+## YAML Frontmatter
+
+sphinx-oceanid supports [Mermaid YAML frontmatter](https://mermaid.js.org/config/frontmatter.html) for setting `title` and `config` within diagram code. The frontmatter block is delimited by `---` markers at the start of the code.
+
+### In external `.mmd` files
+
+This is the recommended way to use frontmatter. Place the YAML block at the top of the file:
+
+```yaml
+---
+title: My Diagram
+config:
+  bg: "#1a1b26"
+  fg: "#a9b1d6"
+---
+flowchart TD
+  A --> B
+```
+
+### In RST inline content
+
+Frontmatter can also be written directly in the directive body:
+
+````rst
+.. mermaid::
+
+   ---
+   title: My Diagram
+   config:
+     bg: "#1a1b26"
+   ---
+   flowchart TD
+     A --> B
+````
+
+### In MyST Markdown
+
+In MyST, the `---` block inside `` ```{mermaid} `` is interpreted as [directive options](https://myst-parser.readthedocs.io/en/latest/syntax/directives.html), not as Mermaid frontmatter. Use `title` and `config` as directive options:
+
+````markdown
+```{mermaid}
+---
+title: My Diagram
+config: {"bg": "#1a1b26", "fg": "#a9b1d6"}
+---
+flowchart TD
+  A --> B
+```
+````
+
+```{note}
+In MyST, the `config` value must be a JSON string on a single line because MyST's option parser does not preserve nested YAML structure. This is the same limitation as [sphinxcontrib-mermaid](https://github.com/mgaitan/sphinxcontrib-mermaid).
+```
+
+### Precedence
+
+Directive options (`:title:`, `:config:`) take precedence over frontmatter values. This allows overriding frontmatter in external files without editing the file itself.
+
+```{note}
+sphinx-oceanid uses [beautiful-mermaid](https://github.com/niccolozy/beautiful-mermaid) as its rendering engine, which has its own color system based on `RenderOptions`. The following `config` keys are applied as per-diagram rendering overrides:
+
+`bg`, `fg`, `line`, `accent`, `muted`, `surface`, `border`, `font`, `padding`, `nodeSpacing`, `layerSpacing`, `componentSpacing`, `transparent`, `interactive`
+
+Standard Mermaid.js configuration keys such as `theme`, `look`, and `themeVariables` are not supported by beautiful-mermaid and will be silently ignored.
+```
+
 ## Directive Options
 
 The `mermaid` directive supports the following options:
@@ -223,9 +330,9 @@ flowchart LR
   A --> B
 ```
 
-### `:title:` — Mermaid native title
+### `:title:` — Diagram title
 
-Sets a native Mermaid title for the diagram. Stored as a `data-oceanid-title` attribute on the diagram container. Unlike `:caption:` (which renders outside the diagram as `<figcaption>`), `:title:` is metadata intended for diagram-internal rendering.
+Sets a title displayed above the rendered diagram. Stored as a `data-oceanid-title` attribute on the diagram container. Unlike `:caption:` (which wraps the diagram in a `<figure>` with `<figcaption>`), `:title:` renders as a heading directly above the SVG.
 
 ::::{tab-set}
 :::{tab-item} RST

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ authors = [
     { name = "driller", email = "eleshis@gmail.com" },
 ]
 dependencies = [
+    "pyyaml",
     "sphinx>=7.4",
 ]
 
@@ -46,6 +47,7 @@ dev = [
     "ruff",
     "mypy",
     "types-docutils",
+    "types-pyyaml",
     { include-group = "test" },
 ]
 docs = [

--- a/src/sphinx_oceanid/_static/oceanid-observer.js
+++ b/src/sphinx_oceanid/_static/oceanid-observer.js
@@ -7,6 +7,57 @@
  *   setupLazyRendering(elements, renderFn, themeColors)
  */
 
+/** Keys from data-oceanid-config that map to beautiful-mermaid RenderOptions. */
+const RENDER_OPTION_KEYS = [
+  "bg", "fg", "line", "accent", "muted", "surface", "border",
+  "font", "padding", "nodeSpacing", "layerSpacing", "componentSpacing",
+  "transparent", "interactive",
+];
+
+/**
+ * Build per-diagram render options by merging page-level theme colors
+ * with diagram-level config (data-oceanid-config).
+ *
+ * Only keys that match beautiful-mermaid RenderOptions are applied;
+ * unknown keys (e.g. Mermaid.js "theme", "look") are silently ignored.
+ *
+ * @param {Element} el - .oceanid-diagram element
+ * @param {object} themeColors - Page-level DiagramColors object
+ * @returns {object} Merged render options
+ */
+const buildDiagramOptions = (el, themeColors) => {
+  const configAttr = el.getAttribute("data-oceanid-config");
+  if (!configAttr) {
+    return { ...themeColors };
+  }
+  try {
+    const config = JSON.parse(configAttr);
+    const overrides = {};
+    for (const key of RENDER_OPTION_KEYS) {
+      if (key in config) {
+        overrides[key] = config[key];
+      }
+    }
+    return { ...themeColors, ...overrides };
+  } catch {
+    return { ...themeColors };
+  }
+};
+
+/**
+ * Insert a title element before the SVG container if data-oceanid-title is set.
+ *
+ * @param {Element} el - .oceanid-diagram element
+ */
+const insertTitle = (el) => {
+  const title = el.getAttribute("data-oceanid-title");
+  if (!title) return;
+  const titleEl = document.createElement("p");
+  titleEl.className = "oceanid-diagram-title";
+  titleEl.textContent = title;
+  el.prepend(titleEl);
+};
+
 /**
  * Render a single diagram element.
  *
@@ -24,7 +75,10 @@ export const renderSingleDiagram = (el, renderFn, themeColors) => {
       throw new Error("data-oceanid-code attribute is missing");
     }
 
-    const svg = renderFn(code, { ...themeColors });
+    const options = buildDiagramOptions(el, themeColors);
+    const svg = renderFn(code, options);
+
+    insertTitle(el);
 
     const container = document.createElement("div");
     container.className = "oceanid-svg-container";

--- a/src/sphinx_oceanid/_static/oceanid.css
+++ b/src/sphinx_oceanid/_static/oceanid.css
@@ -18,6 +18,13 @@
   display: block;
 }
 
+/* Diagram title (from frontmatter or :title: option) */
+.oceanid-diagram-title {
+  font-weight: bold;
+  text-align: center;
+  margin: 0 0 0.5rem;
+}
+
 /* Alignment */
 .oceanid-diagram.align-center {
   text-align: center;

--- a/src/sphinx_oceanid/directives.py
+++ b/src/sphinx_oceanid/directives.py
@@ -14,6 +14,7 @@ from sphinx.util.docutils import SphinxDirective
 
 from .autoclassdiag import class_diagram
 from .diagram_types import extract_diagram_type, is_supported_diagram, unsupported_diagram_message
+from .frontmatter import parse_frontmatter
 from .nodes import mermaid_node
 
 if TYPE_CHECKING:
@@ -48,8 +49,16 @@ class Mermaid(SphinxDirective):
             )
             return []
 
+        code, frontmatter_title, frontmatter_config = self._extract_frontmatter(code)
+
         mermaid_config = self._parse_mermaid_config()
         mermaid_title = self.options.get("title", "")
+
+        # Frontmatter values are used as defaults; directive options take precedence
+        if not mermaid_title and frontmatter_title:
+            mermaid_title = frontmatter_title
+        if not mermaid_config and frontmatter_config:
+            mermaid_config = frontmatter_config
 
         diagram_type = extract_diagram_type(code)
         is_supported = is_supported_diagram(diagram_type)
@@ -116,6 +125,8 @@ class Mermaid(SphinxDirective):
     def _parse_mermaid_config(self) -> dict[str, object]:
         """Parse :config: option into a dict.
 
+        Accepts either a JSON string or a dict (when pre-parsed by MyST).
+
         Returns:
             Parsed config dict, or empty dict if no config, invalid JSON,
             or non-object JSON value.
@@ -123,8 +134,14 @@ class Mermaid(SphinxDirective):
         if "config" not in self.options:
             return {}
 
+        raw = self.options["config"]
+
+        # MyST parser may pass a pre-parsed dict from YAML options block
+        if isinstance(raw, dict):
+            return raw
+
         try:
-            parsed = json.loads(self.options["config"])
+            parsed = json.loads(raw)
         except json.JSONDecodeError as exc:
             logger.warning(
                 "Invalid JSON in :config: option: %s",
@@ -141,6 +158,24 @@ class Mermaid(SphinxDirective):
             location=(self.env.docname, self.lineno),
         )
         return {}
+
+    def _extract_frontmatter(self, code: str) -> tuple[str, str, dict[str, object]]:
+        """Extract YAML frontmatter from Mermaid code.
+
+        Returns:
+            Tuple of (stripped_code, title, config). On parse errors,
+            logs a warning and returns the original code with empty values.
+        """
+        try:
+            result = parse_frontmatter(code)
+        except ValueError as exc:
+            logger.warning(
+                "Invalid Mermaid frontmatter: %s",
+                exc,
+                location=(self.env.docname, self.lineno),
+            )
+            return code, "", {}
+        return result.code, result.title, result.config
 
     def _figure_wrapper(self, node: mermaid_node) -> list[nodes.Node]:
         """Wrap mermaid_node in a figure with figcaption."""

--- a/src/sphinx_oceanid/frontmatter.py
+++ b/src/sphinx_oceanid/frontmatter.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 
 import yaml
 
-_FRONTMATTER_RE = re.compile(r"^---\n(.*?)---\n?", re.DOTALL)
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?)^---[ \t]*$\n?", re.DOTALL | re.MULTILINE)
 
 
 @dataclass(frozen=True)

--- a/src/sphinx_oceanid/frontmatter.py
+++ b/src/sphinx_oceanid/frontmatter.py
@@ -1,0 +1,60 @@
+"""Mermaid YAML frontmatter parsing (pure functions)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+import yaml
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)---\n?", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class FrontmatterResult:
+    """Result of parsing Mermaid YAML frontmatter."""
+
+    code: str
+    title: str = ""
+    config: dict[str, object] = field(default_factory=dict)
+
+
+def parse_frontmatter(code: str) -> FrontmatterResult:
+    """Parse YAML frontmatter from Mermaid code.
+
+    Extracts ``title`` and ``config`` from the ``---``-delimited YAML block
+    at the start of the code. Unknown keys are silently ignored.
+
+    Args:
+        code: Mermaid notation string, possibly prefixed with YAML frontmatter.
+
+    Returns:
+        FrontmatterResult with extracted values and the remaining code.
+
+    Raises:
+        ValueError: If ``title`` is not a string or ``config`` is not a dict.
+    """
+    match = _FRONTMATTER_RE.match(code)
+    if not match:
+        return FrontmatterResult(code=code)
+
+    yaml_block = match.group(1)
+    remaining_code = code[match.end() :]
+
+    parsed = yaml.safe_load(yaml_block)
+    if not isinstance(parsed, dict):
+        return FrontmatterResult(code=remaining_code)
+
+    title = parsed.get("title", "")
+    if title and not isinstance(title, str):
+        raise ValueError(f"Frontmatter 'title' must be a string, got {type(title).__name__}")
+
+    config = parsed.get("config", {})
+    if config and not isinstance(config, dict):
+        raise ValueError(f"Frontmatter 'config' must be a dict, got {type(config).__name__}")
+
+    return FrontmatterResult(
+        code=remaining_code,
+        title=title if isinstance(title, str) else "",
+        config=config if isinstance(config, dict) else {},
+    )

--- a/tests/roots/test-external-frontmatter/conf.py
+++ b/tests/roots/test-external-frontmatter/conf.py
@@ -1,0 +1,2 @@
+extensions = ["sphinx_oceanid"]
+exclude_patterns = ["_build"]

--- a/tests/roots/test-external-frontmatter/diagrams/flow-with-frontmatter.mmd
+++ b/tests/roots/test-external-frontmatter/diagrams/flow-with-frontmatter.mmd
@@ -1,0 +1,10 @@
+---
+title: User Authentication Flow
+config:
+  theme: dark
+  look: handDrawn
+---
+flowchart TD
+  A[Login Page] --> B{Valid credentials?}
+  B -->|Yes| C[Dashboard]
+  B -->|No| D[Error Message]

--- a/tests/roots/test-external-frontmatter/index.rst
+++ b/tests/roots/test-external-frontmatter/index.rst
@@ -1,0 +1,4 @@
+Test
+====
+
+.. mermaid:: diagrams/flow-with-frontmatter.mmd

--- a/tests/roots/test-frontmatter-override/conf.py
+++ b/tests/roots/test-frontmatter-override/conf.py
@@ -1,0 +1,2 @@
+extensions = ["sphinx_oceanid"]
+exclude_patterns = ["_build"]

--- a/tests/roots/test-frontmatter-override/index.rst
+++ b/tests/roots/test-frontmatter-override/index.rst
@@ -1,0 +1,14 @@
+Test
+====
+
+.. mermaid::
+   :title: Option Title
+   :config: {"bg": "#ffffff"}
+
+   ---
+   title: Frontmatter Title
+   config:
+     bg: "#000000"
+   ---
+   flowchart TD
+     A --> B

--- a/tests/roots/test-frontmatter/conf.py
+++ b/tests/roots/test-frontmatter/conf.py
@@ -1,0 +1,2 @@
+extensions = ["sphinx_oceanid"]
+exclude_patterns = ["_build"]

--- a/tests/roots/test-frontmatter/index.rst
+++ b/tests/roots/test-frontmatter/index.rst
@@ -1,0 +1,15 @@
+Test
+====
+
+.. mermaid::
+
+   ---
+   title: Auth Flow
+   config:
+     theme: dark
+     look: handDrawn
+   ---
+   flowchart TD
+     A[Login] --> B{Valid?}
+     B -->|Yes| C[Dashboard]
+     B -->|No| D[Error]

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -71,6 +71,13 @@ class TestParseFrontmatter:
         assert result.title == "Hello"
         assert result.config == {}
 
+    def test_title_containing_dashes(self) -> None:
+        """Title value containing '---' does not break frontmatter parsing."""
+        code = "---\ntitle: A---B\n---\nflowchart TD\n  A --> B"
+        result = parse_frontmatter(code)
+        assert result.title == "A---B"
+        assert result.code == "flowchart TD\n  A --> B"
+
     def test_non_dict_config_raises(self) -> None:
         """Non-dict config value raises ValueError."""
         code = "---\nconfig: not-a-dict\n---\nflowchart TD\n  A --> B"
@@ -153,17 +160,23 @@ class TestExternalFileFrontmatter:
 class TestDirectiveOptionOverridesFrontmatter:
     """Directive options take precedence over frontmatter values."""
 
-    @pytest.mark.sphinx("html", testroot="basic")
-    def test_option_title_not_overridden_by_frontmatter(self, app: Sphinx) -> None:
-        """When :title: option is set, frontmatter title does not override it.
-
-        test-basic has :title: My Diagram Title on a diagram without frontmatter.
-        """
+    @pytest.mark.sphinx("html", testroot="frontmatter-override")
+    def test_option_title_overrides_frontmatter_title(self, app: Sphinx) -> None:
+        """Directive :title: option takes precedence over frontmatter title."""
         app.build()
         doctree = app.env.get_doctree("index")
         nodes = list(doctree.findall(mermaid_node))
-        title_nodes = [n for n in nodes if n.get("mermaid_title")]
-        assert title_nodes[0]["mermaid_title"] == "My Diagram Title"
+        assert len(nodes) >= 1
+        assert nodes[0]["mermaid_title"] == "Option Title"
+
+    @pytest.mark.sphinx("html", testroot="frontmatter-override")
+    def test_option_config_overrides_frontmatter_config(self, app: Sphinx) -> None:
+        """Directive :config: option takes precedence over frontmatter config."""
+        app.build()
+        doctree = app.env.get_doctree("index")
+        nodes = list(doctree.findall(mermaid_node))
+        assert len(nodes) >= 1
+        assert nodes[0]["mermaid_config"] == {"bg": "#ffffff"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -1,0 +1,191 @@
+"""Tests for Mermaid YAML frontmatter parsing and rendering (Issue #57)."""
+
+from __future__ import annotations
+
+import html
+from typing import TYPE_CHECKING
+
+import pytest
+
+from sphinx_oceanid.frontmatter import parse_frontmatter
+from sphinx_oceanid.nodes import mermaid_node
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: Unit tests — parse_frontmatter (no Sphinx)
+# ---------------------------------------------------------------------------
+
+
+class TestParseFrontmatter:
+    """Tests for parse_frontmatter pure function."""
+
+    def test_extract_title(self) -> None:
+        """Title is extracted from YAML frontmatter."""
+        code = "---\ntitle: Auth Flow\n---\nflowchart TD\n  A --> B"
+        result = parse_frontmatter(code)
+        assert result.title == "Auth Flow"
+
+    def test_extract_config(self) -> None:
+        """Config dict is extracted from YAML frontmatter."""
+        code = "---\nconfig:\n  theme: dark\n  look: handDrawn\n---\nflowchart TD\n  A --> B"
+        result = parse_frontmatter(code)
+        assert result.config == {"theme": "dark", "look": "handDrawn"}
+
+    def test_extract_title_and_config(self) -> None:
+        """Both title and config are extracted from frontmatter."""
+        code = "---\ntitle: My Diagram\nconfig:\n  theme: dark\n---\nflowchart TD\n  A --> B"
+        result = parse_frontmatter(code)
+        assert result.title == "My Diagram"
+        assert result.config == {"theme": "dark"}
+
+    def test_strip_frontmatter_from_code(self) -> None:
+        """Frontmatter is stripped from returned code."""
+        code = "---\ntitle: My Title\n---\nflowchart TD\n  A --> B"
+        result = parse_frontmatter(code)
+        assert result.code == "flowchart TD\n  A --> B"
+        assert "---" not in result.code
+
+    def test_no_frontmatter(self) -> None:
+        """Code without frontmatter returns unchanged."""
+        code = "flowchart TD\n  A --> B"
+        result = parse_frontmatter(code)
+        assert result.code == code
+        assert result.title == ""
+        assert result.config == {}
+
+    def test_empty_frontmatter(self) -> None:
+        """Empty frontmatter block is handled."""
+        code = "---\n---\nflowchart TD\n  A --> B"
+        result = parse_frontmatter(code)
+        assert result.code == "flowchart TD\n  A --> B"
+        assert result.title == ""
+        assert result.config == {}
+
+    def test_frontmatter_with_extra_keys_ignored(self) -> None:
+        """Unknown frontmatter keys are silently ignored."""
+        code = "---\ntitle: Hello\nunknownKey: value\n---\nflowchart TD\n  A --> B"
+        result = parse_frontmatter(code)
+        assert result.title == "Hello"
+        assert result.config == {}
+
+    def test_non_dict_config_raises(self) -> None:
+        """Non-dict config value raises ValueError."""
+        code = "---\nconfig: not-a-dict\n---\nflowchart TD\n  A --> B"
+        with pytest.raises(ValueError, match="config"):
+            parse_frontmatter(code)
+
+    def test_non_string_title_raises(self) -> None:
+        """Non-string title value raises ValueError."""
+        code = "---\ntitle:\n  nested: value\n---\nflowchart TD\n  A --> B"
+        with pytest.raises(ValueError, match="title"):
+            parse_frontmatter(code)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: Sphinx integration — directive + frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestFrontmatterDirective:
+    """Tests for RST inline content with YAML frontmatter."""
+
+    @pytest.mark.sphinx("html", testroot="frontmatter")
+    def test_frontmatter_title_stored_on_node(self, app: Sphinx) -> None:
+        """Frontmatter title is stored as mermaid_title on node."""
+        app.build()
+        doctree = app.env.get_doctree("index")
+        nodes = list(doctree.findall(mermaid_node))
+        assert len(nodes) >= 1
+        assert nodes[0]["mermaid_title"] == "Auth Flow"
+
+    @pytest.mark.sphinx("html", testroot="frontmatter")
+    def test_frontmatter_config_stored_on_node(self, app: Sphinx) -> None:
+        """Frontmatter config is stored as mermaid_config on node."""
+        app.build()
+        doctree = app.env.get_doctree("index")
+        nodes = list(doctree.findall(mermaid_node))
+        assert len(nodes) >= 1
+        assert nodes[0]["mermaid_config"] == {"theme": "dark", "look": "handDrawn"}
+
+    @pytest.mark.sphinx("html", testroot="frontmatter")
+    def test_frontmatter_stripped_from_code(self, app: Sphinx) -> None:
+        """Frontmatter is stripped from node code."""
+        app.build()
+        doctree = app.env.get_doctree("index")
+        nodes = list(doctree.findall(mermaid_node))
+        assert "---" not in nodes[0]["code"]
+        assert nodes[0]["code"].startswith("flowchart")
+
+
+class TestExternalFileFrontmatter:
+    """Tests for external .mmd file with YAML frontmatter."""
+
+    @pytest.mark.sphinx("html", testroot="external-frontmatter")
+    def test_external_frontmatter_title(self, app: Sphinx) -> None:
+        """Frontmatter title from external file is stored on node."""
+        app.build()
+        doctree = app.env.get_doctree("index")
+        nodes = list(doctree.findall(mermaid_node))
+        assert len(nodes) >= 1
+        assert nodes[0]["mermaid_title"] == "User Authentication Flow"
+
+    @pytest.mark.sphinx("html", testroot="external-frontmatter")
+    def test_external_frontmatter_config(self, app: Sphinx) -> None:
+        """Frontmatter config from external file is stored on node."""
+        app.build()
+        doctree = app.env.get_doctree("index")
+        nodes = list(doctree.findall(mermaid_node))
+        assert nodes[0]["mermaid_config"] == {"theme": "dark", "look": "handDrawn"}
+
+    @pytest.mark.sphinx("html", testroot="external-frontmatter")
+    def test_external_frontmatter_stripped_from_code(self, app: Sphinx) -> None:
+        """Frontmatter is stripped from code in external file."""
+        app.build()
+        doctree = app.env.get_doctree("index")
+        nodes = list(doctree.findall(mermaid_node))
+        assert "---" not in nodes[0]["code"]
+        assert "flowchart" in nodes[0]["code"]
+
+
+class TestDirectiveOptionOverridesFrontmatter:
+    """Directive options take precedence over frontmatter values."""
+
+    @pytest.mark.sphinx("html", testroot="basic")
+    def test_option_title_not_overridden_by_frontmatter(self, app: Sphinx) -> None:
+        """When :title: option is set, frontmatter title does not override it.
+
+        test-basic has :title: My Diagram Title on a diagram without frontmatter.
+        """
+        app.build()
+        doctree = app.env.get_doctree("index")
+        nodes = list(doctree.findall(mermaid_node))
+        title_nodes = [n for n in nodes if n.get("mermaid_title")]
+        assert title_nodes[0]["mermaid_title"] == "My Diagram Title"
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: HTML output — data attributes in rendered HTML
+# ---------------------------------------------------------------------------
+
+
+class TestFrontmatterHtmlOutput:
+    """Tests for frontmatter values in HTML output."""
+
+    @pytest.mark.sphinx("html", testroot="frontmatter")
+    def test_html_contains_data_oceanid_title(self, app: Sphinx, index: str) -> None:
+        """HTML output includes data-oceanid-title from frontmatter."""
+        assert f'data-oceanid-title="{html.escape("Auth Flow", quote=True)}"' in index
+
+    @pytest.mark.sphinx("html", testroot="frontmatter")
+    def test_html_contains_data_oceanid_config(self, app: Sphinx, index: str) -> None:
+        """HTML output includes data-oceanid-config from frontmatter."""
+        assert "data-oceanid-config=" in index
+
+    @pytest.mark.sphinx("html", testroot="external-frontmatter")
+    def test_external_html_contains_data_oceanid_title(self, app: Sphinx, index: str) -> None:
+        """External file frontmatter title appears in HTML."""
+        assert "data-oceanid-title=" in index
+        assert "User Authentication Flow" in index

--- a/uv.lock
+++ b/uv.lock
@@ -594,6 +594,7 @@ name = "sphinx-oceanid"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
+    { name = "pyyaml" },
     { name = "sphinx" },
 ]
 
@@ -610,6 +611,7 @@ dev = [
     { name = "ruff" },
     { name = "sphinx-revealjs" },
     { name = "types-docutils" },
+    { name = "types-pyyaml" },
 ]
 docs = [
     { name = "myst-parser" },
@@ -627,6 +629,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "pyyaml" },
     { name = "sphinx", specifier = ">=7.4" },
     { name = "sphinx-autobuild", marker = "extra == 'preview'", specifier = ">=2024.0" },
 ]
@@ -640,6 +643,7 @@ dev = [
     { name = "ruff" },
     { name = "sphinx-revealjs" },
     { name = "types-docutils" },
+    { name = "types-pyyaml" },
 ]
 docs = [
     { name = "myst-parser", specifier = ">=5.0.0" },
@@ -742,6 +746,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/27/a7f16b3a2fad0a4ddd85a668319f9a1d0311c4bd9578894f6471c7e6c788/types_docutils-0.22.3.20260316.tar.gz", hash = "sha256:8ef27d565b9831ff094fe2eac75337a74151013e2d21ecabd445c2955f891564", size = 57263, upload-time = "2026-03-16T04:29:12.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/60/c1f22b7cfc4837d5419e5a2d8702c7d65f03343f866364b71cccd8a73b79/types_docutils-0.22.3.20260316-py3-none-any.whl", hash = "sha256:083c7091b8072c242998ec51da1bf1492f0332387da81c3b085efbf5ca754c7d", size = 91968, upload-time = "2026-03-16T04:29:11.114Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New `frontmatter.py` module: pure-function YAML parsing with type validation
- Directives integration: parse YAML, extract config and title, pass to HTML visitor
- Browser-side: `oceanid-observer.js` reads `data-oceanid-config` (RenderOptions) and `data-oceanid-title`
- CSS: new `.oceanid-diagram-title` style for displaying frontmatter titles above diagrams
- Documentation: 3 usage patterns (external .mmd, RST directive, MyST block) with admonitions about beautiful-mermaid config limitations
- Tests: 19 tests (Layer 1-3) covering parsing, validation, Sphinx integration, HTML output

Closes #57

## Test plan

- [x] Unit tests pass: `uv run pytest tests/test_frontmatter.py` (19 tests)
- [x] Integration tests pass: full test suite `uv run pytest` (241 passed)
- [x] Quality checks pass: `ruff check --fix .`, `ruff format .`, `mypy .`
- [x] Sphinx build passes: `make -C docs html`
- [x] Wheel build succeeds: `uv build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)