### PR TITLE
fix: update beautiful-mermaid GitHub links from niccolozy to lukilabs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -5,7 +5,7 @@
 [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://drillan.github.io/sphinx-oceanid/)
 [![English](https://img.shields.io/badge/lang-English-blue)](README.md)
 
-[beautiful-mermaid](https://github.com/niccolozy/beautiful-mermaid) を活用した、Sphinx 向け Mermaid ダイアグラム拡張機能。
+[beautiful-mermaid](https://github.com/lukilabs/beautiful-mermaid) を活用した、Sphinx 向け Mermaid ダイアグラム拡張機能。
 
 ## 特徴
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://drillan.github.io/sphinx-oceanid/)
 [![日本語](https://img.shields.io/badge/lang-日本語-red)](README.ja.md)
 
-Mermaid diagrams in Sphinx, powered by [beautiful-mermaid](https://github.com/niccolozy/beautiful-mermaid).
+Mermaid diagrams in Sphinx, powered by [beautiful-mermaid](https://github.com/lukilabs/beautiful-mermaid).
 
 ## Features
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ All configuration options use the `oceanid_` prefix in your Sphinx `conf.py`.
 | **Type** | `str` |
 | **Default** | `"1.1.3"` |
 
-The [beautiful-mermaid](https://github.com/niccolozy/beautiful-mermaid) library version loaded from CDN. Ignored when `oceanid_local_js` is set.
+The [beautiful-mermaid](https://github.com/lukilabs/beautiful-mermaid) library version loaded from CDN. Ignored when `oceanid_local_js` is set.
 
 ```python
 oceanid_version = "1.1.3"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ Add `sphinx_oceanid` to the `extensions` list in your Sphinx `conf.py`:
 extensions = ["sphinx_oceanid"]
 ```
 
-No additional configuration is required. sphinx-oceanid works out of the box using the CDN-hosted [beautiful-mermaid](https://github.com/niccolozy/beautiful-mermaid) library.
+No additional configuration is required. sphinx-oceanid works out of the box using the CDN-hosted [beautiful-mermaid](https://github.com/lukilabs/beautiful-mermaid) library.
 
 ## Write your first diagram
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -176,7 +176,7 @@ In MyST, the `config` value must be a JSON string on a single line because MyST'
 Directive options (`:title:`, `:config:`) take precedence over frontmatter values. This allows overriding frontmatter in external files without editing the file itself.
 
 ```{note}
-sphinx-oceanid uses [beautiful-mermaid](https://github.com/niccolozy/beautiful-mermaid) as its rendering engine, which has its own color system based on `RenderOptions`. The following `config` keys are applied as per-diagram rendering overrides:
+sphinx-oceanid uses [beautiful-mermaid](https://github.com/lukilabs/beautiful-mermaid) as its rendering engine, which has its own color system based on `RenderOptions`. The following `config` keys are applied as per-diagram rendering overrides:
 
 `bg`, `fg`, `line`, `accent`, `muted`, `surface`, `border`, `font`, `padding`, `nodeSpacing`, `layerSpacing`, `componentSpacing`, `transparent`, `interactive`
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -33,7 +33,7 @@ Add `sphinx_oceanid` to the `extensions` list in your Sphinx `conf.py`:
 extensions = ["sphinx_oceanid"]
 ```
 
-No additional configuration is required. sphinx-oceanid works out of the box using the CDN-hosted [beautiful-mermaid](https://github.com/niccolozy/beautiful-mermaid) library.
+No additional configuration is required. sphinx-oceanid works out of the box using the CDN-hosted [beautiful-mermaid](https://github.com/lukilabs/beautiful-mermaid) library.
 
 ## Local beautiful-mermaid bundle (optional)
 

--- a/docs/supported-diagrams.md
+++ b/docs/supported-diagrams.md
@@ -1,7 +1,7 @@
 (supported-diagram-types)=
 # Supported Diagram Types
 
-sphinx-oceanid uses [beautiful-mermaid](https://github.com/niccolozy/beautiful-mermaid) (an ELK.js-based rendering engine) instead of standard Mermaid.js. beautiful-mermaid supports 6 diagram types with high-quality layout. Standard Mermaid.js supports 20+ types, so diagrams outside these 6 types are not rendered.
+sphinx-oceanid uses [beautiful-mermaid](https://github.com/lukilabs/beautiful-mermaid) (an ELK.js-based rendering engine) instead of standard Mermaid.js. beautiful-mermaid supports 6 diagram types with high-quality layout. Standard Mermaid.js supports 20+ types, so diagrams outside these 6 types are not rendered.
 
 ## Supported types
 
@@ -54,7 +54,7 @@ flowchart LR
 **Known limitations**
 
 - `click` events are not supported
-- Bidirectional arrow (`<-->`) has an SVG rendering bug ([beautiful-mermaid#58](https://github.com/niccolozy/beautiful-mermaid/issues/58))
+- Bidirectional arrow (`<-->`) has an SVG rendering bug ([beautiful-mermaid#58](https://github.com/lukilabs/beautiful-mermaid/issues/58))
 ```
 
 The `graph` keyword is an alias for `flowchart`:
@@ -315,7 +315,7 @@ sequenceDiagram
 - `box` groups are not supported
 - `create` / `destroy` (dynamic actor lifecycle) are not supported
 - Explicit `activate` / `deactivate` commands are not supported (`+`/`-` shorthand only)
-- A note placed before the first message is silently dropped ([beautiful-mermaid#53](https://github.com/niccolozy/beautiful-mermaid/issues/53))
+- A note placed before the first message is silently dropped ([beautiful-mermaid#53](https://github.com/lukilabs/beautiful-mermaid/issues/53))
 ```
 
 ### classDiagram
@@ -459,7 +459,7 @@ See {doc}`index` for full `autoclasstree` options (`:full:`, `:strict:`, `:names
 **Known limitations**
 
 - `click` / `note` / `link` are not supported
-- `classDef` assignments are not reflected in SVG output ([beautiful-mermaid#80](https://github.com/niccolozy/beautiful-mermaid/issues/80))
+- `classDef` assignments are not reflected in SVG output ([beautiful-mermaid#80](https://github.com/lukilabs/beautiful-mermaid/issues/80))
 ```
 
 ### stateDiagram / stateDiagram-v2


### PR DESCRIPTION
## Summary

- Update all beautiful-mermaid GitHub URLs from `niccolozy/beautiful-mermaid` to `lukilabs/beautiful-mermaid` across 7 files (10 occurrences)
- The old `niccolozy/beautiful-mermaid` repository returns 404; the project has moved to `lukilabs/beautiful-mermaid`
- Includes repository links and upstream issue links (#53, #58, #80)

## Test plan

- [ ] Verify all links in README.md and README.ja.md resolve correctly
- [ ] Verify documentation links (docs/*.md) resolve correctly
- [ ] Verify upstream issue links (#53, #58, #80) resolve correctly on the new org

🤖 Generated with [Claude Code](https://claude.com/claude-code)