### PR TITLE
docs(skills): add gh skill install guide and fix SKILL.md frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `mermaid-diagram` skill installable via `gh skill install drillan/sphinx-oceanid mermaid-diagram` (preview)
+- Claude Code skill installation guide in `README.md`, `README.ja.md`, and `docs/install.md`
+- `license: BSD-3-Clause` field in `skills/mermaid-diagram/SKILL.md` frontmatter
+
+### Changed
+
+- Shortened `mermaid-diagram` skill description to satisfy `gh skill publish` recommended max (1024 chars)
+
 ## [0.1.2] - 2026-03-29
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -54,6 +54,20 @@ cd sphinx-oceanid
 pip install .
 ```
 
+## Claude Code スキル（オプション）
+
+本リポジトリには AI コーディングエージェント向けの [`mermaid-diagram`](skills/mermaid-diagram/SKILL.md) スキルが同梱されています。プロアクティブな図の提案、構文検証、対応 6 種すべてのサンプルを提供します。
+
+[`gh skill install`](https://docs.github.com/ja/copilot/customizing-copilot/agent-skills)（プレビュー、GitHub CLI 2.91 以上が必要）でインストール：
+
+```bash
+gh skill install drillan/sphinx-oceanid mermaid-diagram --agent claude-code
+```
+
+`--agent` で指定可能な値： `claude-code`, `github-copilot`, `cursor`, `codex`, `gemini`, `antigravity`。
+
+`--scope user` でユーザー全体にインストール可能です。詳細・バージョン pin・更新方法は [docs/install.md](docs/install.md#claude-code-skill) を参照してください。
+
 ## クイックスタート
 
 `conf.py` に拡張機能を追加します：

--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ cd sphinx-oceanid
 pip install .
 ```
 
+## Claude Code Skill (Optional)
+
+This repository ships a [`mermaid-diagram`](skills/mermaid-diagram/SKILL.md) skill for AI coding agents. It provides proactive diagram suggestions, syntax validation, and ready-made examples for all 6 supported diagram types.
+
+Install it with [`gh skill install`](https://docs.github.com/en/copilot/customizing-copilot/agent-skills) (preview, requires GitHub CLI 2.91+):
+
+```bash
+gh skill install drillan/sphinx-oceanid mermaid-diagram --agent claude-code
+```
+
+Supported `--agent` values: `claude-code`, `github-copilot`, `cursor`, `codex`, `gemini`, `antigravity`.
+
+Use `--scope user` to install globally instead of per-project. See [docs/install.md](docs/install.md#claude-code-skill) for details, version pinning, and update workflow.
+
 ## Quick Start
 
 Add the extension to your `conf.py`:

--- a/docs/install.md
+++ b/docs/install.md
@@ -92,3 +92,53 @@ pip install sphinx-autobuild
 ```bash
 make serve PORT=9000
 ```
+
+## Claude Code Skill
+
+sphinx-oceanid ships a `mermaid-diagram` skill that gives AI coding agents (Claude Code, GitHub Copilot, Cursor, etc.) proactive Mermaid suggestions and syntax validation while editing Sphinx docs.
+
+### Prerequisites
+
+- [GitHub CLI](https://cli.github.com/) **2.91 or later** (the `gh skill` extension is bundled; preview)
+
+### Install
+
+```bash
+gh skill install drillan/sphinx-oceanid mermaid-diagram --agent claude-code
+```
+
+Supported `--agent` values and install destinations:
+
+| Agent | Project scope (default) | User scope (`--scope user`) |
+|-------|--------------------------|------------------------------|
+| `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
+| `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
+| `cursor` | `.agents/skills/` | `~/.cursor/skills/` |
+| `codex`, `gemini`, `antigravity` | `.agents/skills/` | per-agent default |
+
+### Pin to a specific version
+
+```bash
+gh skill install drillan/sphinx-oceanid mermaid-diagram \
+    --agent claude-code --pin v0.1.2
+```
+
+### Update or remove
+
+```bash
+gh skill update --all              # update every installed skill
+gh skill update mermaid-diagram    # update only this skill
+```
+
+To remove the skill, delete its directory (e.g., `rm -rf .claude/skills/mermaid-diagram`).
+
+### Manual install (without gh CLI)
+
+Clone the repository and copy the skill directory:
+
+```bash
+git clone https://github.com/drillan/sphinx-oceanid.git
+cp -r sphinx-oceanid/skills/mermaid-diagram .claude/skills/
+```
+
+Manually placed skills are not tracked by `gh skill update`.

--- a/skills/mermaid-diagram/SKILL.md
+++ b/skills/mermaid-diagram/SKILL.md
@@ -1,31 +1,24 @@
 ---
 name: mermaid-diagram
+license: BSD-3-Clause
 description: >
   Write Mermaid diagrams in Sphinx documentation using sphinx-oceanid.
   Supports both MyST Markdown (.md) and reStructuredText (.rst) syntax.
   Prevents common mistakes like using unsupported diagram types.
 
   MUST trigger when:
-  - Editing or creating .md or .rst files under docs/ in a project where
-    docs/conf.py contains sphinx_oceanid in the extensions list
-  - User asks to add a diagram, flowchart, sequence diagram, class diagram,
-    state diagram, ER diagram, or chart to documentation
-  - User mentions 'mermaid', 'diagram', or wants to visualize architecture,
-    workflows, data flows, class hierarchies, or state machines in their docs
+  - Editing .md/.rst files under docs/ where docs/conf.py contains sphinx_oceanid
+  - User asks to add a diagram (flowchart, sequence, class, state, ER, chart)
+  - User mentions 'mermaid'/'diagram' or wants to visualize architecture,
+    workflows, data flows, hierarchies, or state machines
 
-  SHOULD trigger proactively when:
-  - Writing documentation that describes processes, workflows, or step-by-step
-    flows (suggest flowchart)
-  - Writing documentation that describes component interactions or API calls
-    (suggest sequenceDiagram)
-  - Writing documentation that describes class hierarchies or module
-    relationships (suggest classDiagram)
-  - Writing documentation that describes state transitions or lifecycles
-    (suggest stateDiagram)
-  - Writing documentation that describes data models or entity relationships
-    (suggest erDiagram)
-  - Writing documentation that describes numeric data, comparisons, or trends
-    (suggest xychart-beta)
+  SHOULD trigger proactively when documentation describes:
+  - Processes/workflows (suggest flowchart)
+  - Component interactions or API calls (suggest sequenceDiagram)
+  - Class hierarchies or module relationships (suggest classDiagram)
+  - State transitions or lifecycles (suggest stateDiagram)
+  - Data models or entity relationships (suggest erDiagram)
+  - Numeric data, comparisons, or trends (suggest xychart-beta)
 ---
 
 # Mermaid Diagrams with sphinx-oceanid


### PR DESCRIPTION
## Summary

- Resolve `gh skill publish --dry-run` warnings on the `mermaid-diagram` skill
  (description length 1257→944 chars, add `license: BSD-3-Clause` field)
- Add a "Claude Code Skill" section to `README.md`, `README.ja.md`, and
  `docs/install.md` documenting `gh skill install drillan/sphinx-oceanid mermaid-diagram`
- Record both changes in `CHANGELOG.md` `[Unreleased]`

## Background

`gh skill publish --dry-run` reported two warnings:
1. description exceeds the recommended max of 1024 chars
2. recommended `license` field missing

Additionally, the repository already supports `gh skill install` but the
README and docs had no guidance for users to discover/install the skill.

The remaining warning ("no active tag protection rulesets") is a GitHub
repository-level setting (Settings > Rules > Rulesets) and is intentionally
out of scope for this PR.

## Test plan

- [x] `gh skill publish --dry-run` — only the tag-protection warning remains
- [x] `uv run ruff check --fix .` — All checks passed
- [x] `uv run ruff format .` — 43 files left unchanged
- [x] `uv run mypy .` — Success: no issues found in 27 source files
- [x] `uv run pytest` — 243 passed
- [x] `uv build` — wheel/sdist build succeeds, LICENSE/`_static`/`py.typed` present
- [x] `make -C docs html` — build succeeded; `id="claude-code-skill"` anchor verified in `install.html`
- [x] README章立て英日同期確認 (11 sections aligned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)