### PR TITLE
feat!(config): change oceanid_zoom and oceanid_fullscreen defaults to True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Shortened `mermaid-diagram` skill description to satisfy `gh skill publish` recommended max (1024 chars)
+- **Breaking**: `oceanid_zoom` default changed from `False` to `True` — pan-and-zoom is now enabled on all diagrams by default. Set `oceanid_zoom = False` in `conf.py` to restore previous behavior.
+- **Breaking**: `oceanid_fullscreen` default changed from `False` to `True` — the fullscreen button is now shown on all diagrams by default. Set `oceanid_fullscreen = False` in `conf.py` to restore previous behavior.
 
 ## [0.1.2] - 2026-03-29
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -121,11 +121,11 @@ oceanid_theme = "auto"
 oceanid_theme_dark = "zinc-dark"
 oceanid_theme_light = "zinc-light"
 
-# 全ダイアグラムでズームを有効化（デフォルト: False）
-oceanid_zoom = True
+# 全ダイアグラムでズームを有効化（デフォルト: True）
+oceanid_zoom = False
 
-# フルスクリーンモーダルを有効化（デフォルト: False）
-oceanid_fullscreen = True
+# フルスクリーンモーダルを有効化（デフォルト: True）
+oceanid_fullscreen = False
 
 # 非対応ダイアグラムタイプへの対応: "warning" または "error"（デフォルト: "warning"）
 oceanid_unsupported_action = "warning"

--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ oceanid_theme = "auto"
 oceanid_theme_dark = "zinc-dark"
 oceanid_theme_light = "zinc-light"
 
-# Enable zoom on all diagrams (default: False)
-oceanid_zoom = True
+# Enable zoom on all diagrams (default: True)
+oceanid_zoom = False
 
-# Enable fullscreen modal (default: False)
-oceanid_fullscreen = True
+# Enable fullscreen modal (default: True)
+oceanid_fullscreen = False
 
 # Action for unsupported diagram types: "warning" or "error" (default: "warning")
 oceanid_unsupported_action = "warning"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,14 +123,14 @@ oceanid_height = "400px"
 | | |
 |---|---|
 | **Type** | `bool` |
-| **Default** | `False` |
+| **Default** | `True` |
 
 Enable pan-and-zoom interaction on all diagrams globally. Uses native Pointer Events and SVG viewBox manipulation — no d3.js dependency. Mouse wheel to zoom, drag to pan, double-click to reset, pinch to zoom on touch devices.
 
-To enable zoom on individual diagrams only, use the `:zoom:` directive option instead.
+Set to `False` to disable globally; you can still opt in per-diagram with the `:zoom:` directive option.
 
 ```python
-oceanid_zoom = True
+oceanid_zoom = False
 ```
 
 ### `oceanid_fullscreen`
@@ -138,12 +138,14 @@ oceanid_zoom = True
 | | |
 |---|---|
 | **Type** | `bool` |
-| **Default** | `False` |
+| **Default** | `True` |
 
 Enable a fullscreen button on all diagrams. Clicking it opens the diagram in a viewport-sized modal overlay. Close with Escape key, clicking outside, or the close button.
 
+Set to `False` to hide the fullscreen button on all diagrams.
+
 ```python
-oceanid_fullscreen = True
+oceanid_fullscreen = False
 ```
 
 ### `oceanid_fullscreen_button`
@@ -184,8 +186,8 @@ oceanid_fullscreen_button_opacity = 80
 | `oceanid_theme_light` | `str` | `"zinc-light"` | Light theme for auto mode |
 | `oceanid_width` | `str` | `"100%"` | Diagram container width |
 | `oceanid_height` | `str` | `"auto"` | Diagram container height |
-| `oceanid_zoom` | `bool` | `False` | Enable zoom globally |
-| `oceanid_fullscreen` | `bool` | `False` | Enable fullscreen modal |
+| `oceanid_zoom` | `bool` | `True` | Enable zoom globally |
+| `oceanid_fullscreen` | `bool` | `True` | Enable fullscreen modal |
 | `oceanid_fullscreen_button` | `str` | `"⛶"` | Fullscreen button character |
 | `oceanid_fullscreen_button_opacity` | `int` | `50` | Button opacity (0–100) |
 

--- a/src/sphinx_oceanid/config.py
+++ b/src/sphinx_oceanid/config.py
@@ -45,8 +45,8 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
     ConfigSpec("oceanid_width", "100%", "html", str, "Diagram container width"),
     ConfigSpec("oceanid_height", "auto", "html", str, "Diagram container height"),
     # Feature flags
-    ConfigSpec("oceanid_zoom", False, "html", bool, "Enable zoom on all diagrams"),
-    ConfigSpec("oceanid_fullscreen", False, "html", bool, "Enable fullscreen modal"),
+    ConfigSpec("oceanid_zoom", True, "html", bool, "Enable zoom on all diagrams"),
+    ConfigSpec("oceanid_fullscreen", True, "html", bool, "Enable fullscreen modal"),
     ConfigSpec("oceanid_fullscreen_button", "\u26f6", "html", str, "Fullscreen button character"),
     ConfigSpec("oceanid_fullscreen_button_opacity", 50, "html", int, "Fullscreen button opacity (0-100)"),
 )


### PR DESCRIPTION
## Summary

Enable zoom and fullscreen functionality by default on all Mermaid diagrams. This is a breaking change that makes sphinx-oceanid's core UX features available out-of-the-box while building the user base. Existing deployments can restore the previous behavior by explicitly setting `oceanid_zoom = False` and `oceanid_fullscreen = False` in their Sphinx `conf.py`.

## Breaking Change Warning

**Default value changes:**
- `oceanid_zoom`: `False` → `True`
- `oceanid_fullscreen`: `False` → `True`

To maintain the previous behavior (no zoom/fullscreen buttons), add to `conf.py`:
```python
oceanid_zoom = False
oceanid_fullscreen = False
```

## Test plan

- [x] Local ruff check (--fix and format): All checks passed
- [x] Local mypy type checking: 27 source files, no issues
- [x] Local pytest suite: 243 tests passed
- [x] Local Sphinx docs build: Documentation built successfully
- [x] Configuration updated: config.py defaults changed
- [x] Documentation updated: configuration.md, README.md, README.ja.md, CHANGELOG.md
- [x] No regressions: All existing tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)