### PR TITLE
Release version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-29
+
 ### Added
 
 - `mermaid-diagram` skill installable via `gh skill install drillan/sphinx-oceanid mermaid-diagram` (preview)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sphinx-oceanid"
-version = "0.1.2"
+version = "0.2.0"
 description = "Mermaid diagrams in Sphinx, powered by beautiful-mermaid"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -35,7 +35,7 @@ class TestProjectMetadata:
         assert project["name"] == "sphinx-oceanid"
 
     def test_version(self, project: dict[str, object]) -> None:
-        assert project["version"] == "0.1.2"
+        assert project["version"] == "0.2.0"
 
     def test_requires_python(self, project: dict[str, object]) -> None:
         assert project["requires-python"] == ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,7 @@ wheels = [
 
 [[package]]
 name = "sphinx-oceanid"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

Bump version from 0.1.2 to 0.2.0 to reflect breaking changes introduced in PR #61.

PR #61 changed default values for `oceanid_zoom` and `oceanid_fullscreen` from False to True. Per SemVer 0.x conventions, MINOR version bump is the appropriate response to breaking changes in pre-release cycles. This ensures proper dependency resolution in package managers.

CHANGELOG.md updated and release marked as of 2026-04-29.

## Test plan

- [x] `ruff check .` — All checks passed
- [x] `mypy .` — 27 source files, no issues
- [x] `pytest` — 243 tests passed (including test_metadata version assertion)
- [x] All modified files staged and committed
- [x] Branch pushed to origin with tracking enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)