### PR TITLE
chore(pyproject): fix uv_build constraint and remove deprecated license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ keywords = ["sphinx", "mermaid", "diagrams", "documentation", "beautiful-mermaid
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Framework :: Sphinx :: Extension",
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Topic :: Documentation",
@@ -31,7 +30,7 @@ Repository = "https://github.com/drillan/sphinx-oceanid"
 Changelog = "https://github.com/drillan/sphinx-oceanid/blob/main/CHANGELOG.md"
 
 [build-system]
-requires = ["uv_build>=0.10.0,<0.11.0"]
+requires = ["uv_build>=0.11.0,<0.12.0"]
 build-backend = "uv_build"
 
 [project.optional-dependencies]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -49,7 +49,6 @@ class TestProjectMetadata:
         expected = [
             "Development Status :: 3 - Alpha",
             "Framework :: Sphinx :: Extension",
-            "License :: OSI Approved :: BSD License",
             "Programming Language :: Python :: 3.13",
             "Programming Language :: Python :: 3.14",
             "Topic :: Documentation",


### PR DESCRIPTION
## Summary

Resolves two non-blocking warnings observed in the v0.2.0 publish workflow run:

- `warning: build_system.requires = ["uv-build>=0.10.0,<0.11.0"] does not contain the current uv version 0.11.8`
- `warning: Found license classifier 'License :: OSI Approved :: BSD License'. License classifiers are ambiguous and deprecated per PEP 639`

## Changes

- **`pyproject.toml`**
  - Bump `[build-system].requires` from `uv_build>=0.10.0,<0.11.0` to `>=0.11.0,<0.12.0` to match the current uv 0.11.x release family.
  - Remove the deprecated `License :: OSI Approved :: BSD License` classifier. The project already declares `license = "BSD-3-Clause"` and `license-files = ["LICENSE"]` (PEP 639 compliant), so the classifier was redundant.
- **`tests/test_metadata.py`**
  - Sync the expected classifier list with the new value.

## Test plan

- [x] `ruff check --fix .` — All checks passed
- [x] `ruff format .` — 43 files left unchanged
- [x] `mypy .` — Success: no issues found in 27 source files
- [x] `pytest` — 243 passed, 8 warnings (pre-existing sphinx_revealjs deprecation, unrelated)
- [x] `uv build` — wheel + sdist built without warnings; verified METADATA contains `License-Expression: BSD-3-Clause` and no deprecated `Classifier: License :: ...`; LICENSE (1494 bytes), all `_static/` files, and `py.typed` are bundled.

## Related

- Workflow run with original warnings: https://github.com/drillan/sphinx-oceanid/actions/runs/25100294272
- The Node.js 20 deprecation warnings from the same run are tracked separately in #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)