### PR TITLE
docs(readme): align config example values with new True defaults

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -122,10 +122,10 @@ oceanid_theme_dark = "zinc-dark"
 oceanid_theme_light = "zinc-light"
 
 # 全ダイアグラムでズームを有効化（デフォルト: True）
-oceanid_zoom = False
+oceanid_zoom = True
 
 # フルスクリーンモーダルを有効化（デフォルト: True）
-oceanid_fullscreen = False
+oceanid_fullscreen = True
 
 # 非対応ダイアグラムタイプへの対応: "warning" または "error"（デフォルト: "warning"）
 oceanid_unsupported_action = "warning"

--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ oceanid_theme_dark = "zinc-dark"
 oceanid_theme_light = "zinc-light"
 
 # Enable zoom on all diagrams (default: True)
-oceanid_zoom = False
+oceanid_zoom = True
 
 # Enable fullscreen modal (default: True)
-oceanid_fullscreen = False
+oceanid_fullscreen = True
 
 # Action for unsupported diagram types: "warning" or "error" (default: "warning")
 oceanid_unsupported_action = "warning"


### PR DESCRIPTION
## Summary

PR #61 で `oceanid_zoom` と `oceanid_fullscreen` のデフォルト値を `True` に変更したが、`README.md` / `README.ja.md` の Configuration コードブロックではコメントだけ `(default: True)` に更新され、代入値は `False` のまま残っていた。

```python
# Enable zoom on all diagrams (default: True)
oceanid_zoom = False     # ← 矛盾していた

# Enable fullscreen modal (default: True)
oceanid_fullscreen = False  # ← 矛盾していた
```

README の Configuration ブロックは他の設定（`oceanid_theme = "auto"` など）が **すべて実際のデフォルト値** で並んでいるスタイルなので、このブロックの一貫性に合わせて代入値も `True` に揃える。

詳細な opt-out 例（無効化する方法）は `docs/configuration.md` が個別セクションで担当しているため、そちらは変更不要。

## Changes

- `README.md`: `oceanid_zoom = True`, `oceanid_fullscreen = True`
- `README.ja.md`: 同上（日本語版）

## Test plan

- [x] ローカルで pre-push-check を完走
  - ruff check --fix / ruff format / mypy: 全て pass
  - pytest: 243 passed
  - `uv build`: wheel 生成成功（LICENSE / _static / py.typed / METADATA すべて検証済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)